### PR TITLE
Add dark mode toggle for improved UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ export type DrawdownStrategies =
 
 export default function App() {
   const round2 = (n: number) => Math.round(n * 100) / 100;
+  const [darkMode, setDarkMode] = useState(false);
   const [activeTab, setActiveTab] = useState<"sp500" | "nasdaq100" | "portfolio" | "drawdown">("sp500");
   const [cash, setCash] = useState(100_000);
   const [spy, setSpy] = useState(450_000);
@@ -40,6 +41,8 @@ export default function App() {
   const [seed, setSeed] = useState<number | "">("");
   const [refreshCounter, setRefreshCounter] = useState(0);
   const [startYear, setStartYear] = useState<number>(1986); // Default start year
+
+  const toggleDarkMode = () => setDarkMode((prev) => !prev);
 
   const handleParamChange = (param: string, value: string | number | boolean) => {
     switch (param) {
@@ -90,11 +93,18 @@ export default function App() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 text-slate-900 p-6">
-      <div className="max-w-6xl mx-auto space-y-6">
-        <header className="flex items-center justify-between">
-          <h1 className="text-2xl md:text-3xl font-bold">4% Rule Tester — Monte Carlo</h1>
-        </header>
+    <div className={darkMode ? "dark" : ""}>
+      <div className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-100 p-6">
+        <div className="max-w-6xl mx-auto space-y-6">
+          <header className="flex items-center justify-between">
+            <h1 className="text-2xl md:text-3xl font-bold">4% Rule Tester — Monte Carlo</h1>
+            <button
+              className="px-3 py-1 rounded bg-slate-200 text-slate-800 dark:bg-slate-700 dark:text-slate-100"
+              onClick={toggleDarkMode}
+            >
+              {darkMode ? "Light Mode" : "Dark Mode"}
+            </button>
+          </header>
 
         <TabNavigation
           activeTab={activeTab}
@@ -187,6 +197,7 @@ export default function App() {
             refreshCounter={refreshCounter}
           />
         )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -7,27 +7,35 @@ interface TabNavigationProps {
 
 const TabNavigation: React.FC<TabNavigationProps> = ({ activeTab, onTabChange }) => {
   return (
-    <div className="flex border-b border-slate-200 mb-6">
+    <div className="flex border-b border-slate-200 dark:border-slate-700 mb-6">
       <button
-        className={`px-4 py-2 font-medium ${activeTab === 'sp500' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-slate-500 hover:text-slate-700'}`}
+        className={`px-4 py-2 font-medium ${activeTab === 'sp500'
+          ? 'text-blue-600 border-b-2 border-blue-600 dark:text-blue-400 dark:border-blue-400'
+          : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}`}
         onClick={() => onTabChange('sp500')}
       >
         S&P 500
       </button>
       <button
-        className={`px-4 py-2 font-medium ${activeTab === 'nasdaq100' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-slate-500 hover:text-slate-700'}`}
+        className={`px-4 py-2 font-medium ${activeTab === 'nasdaq100'
+          ? 'text-blue-600 border-b-2 border-blue-600 dark:text-blue-400 dark:border-blue-400'
+          : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}`}
         onClick={() => onTabChange('nasdaq100')}
       >
         NASDAQ 100
       </button>
       <button
-        className={`px-4 py-2 font-medium ${activeTab === 'portfolio' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-slate-500 hover:text-slate-700'}`}
+        className={`px-4 py-2 font-medium ${activeTab === 'portfolio'
+          ? 'text-blue-600 border-b-2 border-blue-600 dark:text-blue-400 dark:border-blue-400'
+          : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}`}
         onClick={() => onTabChange('portfolio')}
       >
         Portfolio
       </button>
       <button
-        className={`px-4 py-2 font-medium ${activeTab === 'drawdown' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-slate-500 hover:text-slate-700'}`}
+        className={`px-4 py-2 font-medium ${activeTab === 'drawdown'
+          ? 'text-blue-600 border-b-2 border-blue-600 dark:text-blue-400 dark:border-blue-400'
+          : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}`}
         onClick={() => onTabChange('drawdown')}
       >
         Drawdown Strategies

--- a/src/index.css
+++ b/src/index.css
@@ -3,4 +3,4 @@
 @tailwind utilities;
 
 /* optional sanity check: this will make the page obvious if Tailwind compiled */
-body { @apply bg-slate-100 text-slate-900; }
+body { @apply bg-slate-100 text-slate-900 dark:bg-slate-900 dark:text-slate-100; }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: { extend: {} },
   plugins: [],


### PR DESCRIPTION
## Summary
- add class-based dark mode support in Tailwind config and base styles
- introduce dark mode toggle button in header and adjust tab styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3455bc7788324ba6f2921107194b5