### PR TITLE
Add custom favicon and update site title

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Bucket Retirement Calculator</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M16 20h32l-4 28H20l-4-28z" fill="#90caf9" stroke="#0d47a1" stroke-width="4"/>
+  <path d="M20 20c0-8 6-14 12-14s12 6 12 14" fill="none" stroke="#0d47a1" stroke-width="4"/>
+</svg>


### PR DESCRIPTION
## Summary
- replace default Vite title with "Bucket Retirement Calculator"
- add bucket-themed favicon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3462cb0bc83249d04c5b848239759