### PR TITLE
Fix inflation rate input rounding

### DIFF
--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -517,7 +517,17 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
           </div>
           <label className="block text-sm">Assumed Inflation Rate
             <div className="flex items-center mt-1">
-              <input type="number" className="w-full border rounded-xl p-2" value={inflationRate * 100} step={0.5} onChange={e => onParamChange('inflationRate', parseFloat(e.target.value) / 100)} />
+              <input
+                type="number"
+                className="w-full border rounded-xl p-2"
+                value={Math.round(inflationRate * 200) / 2}
+                step={0.5}
+                onChange={e =>
+                  onParamChange(
+                    'inflationRate',
+                    Math.round(parseFloat(e.target.value) * 2) / 200,
+                  )}
+              />
               <span className="ml-2">%</span>
             </div>
           </label>

--- a/src/components/Nasdaq100Tab.tsx
+++ b/src/components/Nasdaq100Tab.tsx
@@ -227,7 +227,17 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
           </div>
           <label className="block text-sm">Assumed Inflation Rate
             <div className="flex items-center mt-1">
-              <input type="number" className="w-full border rounded-xl p-2" value={inflationRate * 100} step={0.5} onChange={e => onParamChange('inflationRate', parseFloat(e.target.value) / 100)} />
+              <input
+                type="number"
+                className="w-full border rounded-xl p-2"
+                value={Math.round(inflationRate * 200) / 2}
+                step={0.5}
+                onChange={e =>
+                  onParamChange(
+                    'inflationRate',
+                    Math.round(parseFloat(e.target.value) * 2) / 200,
+                  )}
+              />
               <span className="ml-2">%</span>
             </div>
           </label>

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -336,7 +336,17 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
           </div>
           <label className="block text-sm">Assumed Inflation Rate
             <div className="flex items-center mt-1">
-              <input type="number" className="w-full border rounded-xl p-2" value={inflationRate * 100} step={0.5} onChange={e => onParamChange('inflationRate', parseFloat(e.target.value) / 100)} />
+              <input
+                type="number"
+                className="w-full border rounded-xl p-2"
+                value={Math.round(inflationRate * 200) / 2}
+                step={0.5}
+                onChange={e =>
+                  onParamChange(
+                    'inflationRate',
+                    Math.round(parseFloat(e.target.value) * 2) / 200,
+                  )}
+              />
               <span className="ml-2">%</span>
             </div>
           </label>

--- a/src/components/S&P500Tab.tsx
+++ b/src/components/S&P500Tab.tsx
@@ -227,7 +227,17 @@ const SPTab: React.FC<SPTabProps> = ({
           </div>
           <label className="block text-sm">Assumed Inflation Rate
             <div className="flex items-center mt-1">
-              <input type="number" className="shrink border rounded-xl p-2" value={inflationRate * 100} step={0.5} onChange={e => onParamChange('inflationRate', parseFloat(e.target.value) / 100)} />
+              <input
+                type="number"
+                className="shrink border rounded-xl p-2"
+                value={Math.round(inflationRate * 200) / 2}
+                step={0.5}
+                onChange={e =>
+                  onParamChange(
+                    'inflationRate',
+                    Math.round(parseFloat(e.target.value) * 2) / 200,
+                  )}
+              />
               <span className="ml-2">%</span>
             </div>
           </label>


### PR DESCRIPTION
## Summary
- Ensure inflation rate inputs display in 0.5% increments without floating point artifacts
- Apply rounding logic on Drawdown, Nasdaq100, Portfolio, and S&P500 tabs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a35d44af0883248880e58420e0904c