### PR TITLE
feat: persist parameters across sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
-import { useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
+import { usePersistentState } from "./hooks/usePersistentState";
 import { SP500_TOTAL_RETURNS, NASDAQ100_TOTAL_RETURNS } from "./data/returns";
 import { TEN_YEAR_TREASURY_TOTAL_RETURNS } from "./data/bonds";
 import TabNavigation from "./components/TabNavigation";
@@ -24,24 +24,24 @@ export type DrawdownStrategies =
 
 export default function App() {
   const round2 = (n: number) => Math.round(n * 100) / 100;
-  const [darkMode, setDarkMode] = useState(false);
-  const [activeTab, setActiveTab] = useState<"sp500" | "nasdaq100" | "portfolio" | "drawdown">("sp500");
-  const [cash, setCash] = useState(100_000);
-  const [spy, setSpy] = useState(450_000);
-  const [qqq, setQqq] = useState(450_000);
-  const [bonds, setBonds] = useState(0);
+  const [darkMode, setDarkMode] = usePersistentState<boolean>("darkMode", false);
+  const [activeTab, setActiveTab] = usePersistentState<"sp500" | "nasdaq100" | "portfolio" | "drawdown">("activeTab", "sp500");
+  const [cash, setCash] = usePersistentState("cash", 100_000);
+  const [spy, setSpy] = usePersistentState("spy", 450_000);
+  const [qqq, setQqq] = usePersistentState("qqq", 450_000);
+  const [bonds, setBonds] = usePersistentState("bonds", 0);
   const portfolioStartBalance = useMemo(() => cash + spy + qqq + bonds, [cash, spy, qqq, bonds]);
-  const [startBalance, setStartBalance] = useState(1_000_000);
-  const [drawdownStrategy, setDrawdownStrategy] = useState<DrawdownStrategy>("cashFirst_spyThenQqq");
-  const [horizon, setHorizon] = useState(30);
-  const [withdrawRate, setWithdrawRate] = useState(4); // % of initial
-  const [initialWithdrawalAmount, setInitialWithdrawalAmount] = useState(Math.round(startBalance * (4 / 100)));
-  const [isInitialAmountLocked, setIsInitialAmountLocked] = useState(false);
-  const [inflationAdjust, setInflationAdjust] = useState(true);
-  const [inflationRate, setInflationRate] = useState(0.02); // 2%
-  const [mode, setMode] = useState<"actual-seq" | "actual-seq-random-start" | "random-shuffle" | "bootstrap">("actual-seq");
-  const [numRuns, setNumRuns] = useState(1000);
-  const [seed, setSeed] = useState<number | "">("");
+  const [startBalance, setStartBalance] = usePersistentState("startBalance", 1_000_000);
+  const [drawdownStrategy, setDrawdownStrategy] = usePersistentState<DrawdownStrategy>("drawdownStrategy", "cashFirst_spyThenQqq");
+  const [horizon, setHorizon] = usePersistentState("horizon", 30);
+  const [withdrawRate, setWithdrawRate] = usePersistentState("withdrawRate", 4); // % of initial
+  const [initialWithdrawalAmount, setInitialWithdrawalAmount] = usePersistentState("initialWithdrawalAmount", Math.round(startBalance * (4 / 100)));
+  const [isInitialAmountLocked, setIsInitialAmountLocked] = usePersistentState("isInitialAmountLocked", false);
+  const [inflationAdjust, setInflationAdjust] = usePersistentState("inflationAdjust", true);
+  const [inflationRate, setInflationRate] = usePersistentState("inflationRate", 0.02); // 2%
+  const [mode, setMode] = usePersistentState<"actual-seq" | "actual-seq-random-start" | "random-shuffle" | "bootstrap">("mode", "actual-seq");
+  const [numRuns, setNumRuns] = usePersistentState("numRuns", 1000);
+  const [seed, setSeed] = usePersistentState<number | "">("seed", "");
   const [refreshCounter, setRefreshCounter] = useState(0);
   const years = useMemo(() => {
     const spyYears = new Set(SP500_TOTAL_RETURNS.map(d => d.year));
@@ -49,7 +49,7 @@ export default function App() {
     const bondYears = new Set(TEN_YEAR_TREASURY_TOTAL_RETURNS.map(d => d.year));
     return Array.from(spyYears).filter(y => qqqYears.has(y) && bondYears.has(y)).sort((a, b) => a - b);
   }, []);
-  const [startYear, setStartYear] = useState<number>(years[0]);
+  const [startYear, setStartYear] = usePersistentState("startYear", years[0]);
 
   const toggleDarkMode = () => setDarkMode((prev) => !prev);
 

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from "react";
+
+export function usePersistentState<T>(key: string, defaultValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      return stored !== null ? (JSON.parse(stored) as T) : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // ignore write errors
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}


### PR DESCRIPTION
## Summary
- store user-defined values in localStorage via new `usePersistentState` hook
- preserve balances, rates, and other simulation settings on reload

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a36a49253c83248d6e24f41d62bfb1