### PR TITLE
feat: include bonds in drawdown simulations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -192,6 +192,7 @@ export default function App() {
             cash={cash}
             spy={spy}
             qqq={qqq}
+            bonds={bonds}
             horizon={horizon}
             withdrawRate={withdrawRate}
             initialWithdrawalAmount={initialWithdrawalAmount}


### PR DESCRIPTION
## Summary
- simulate drawdown strategies with 10Y Treasury bond returns
- accept bond allocations in the drawdown tab UI and pass through to simulations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a368f9da5083249f77b682d6dec6ef