### PR TITLE
Allow editing unlocked initial withdrawal and fix typo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,12 +62,18 @@ export default function App() {
       case 'bonds': setBonds(parseFloat(value as string)); break;
       case 'drawdownStrategy': setDrawdownStrategy(value as DrawdownStrategy); break;
       case 'horizon': setHorizon(parseFloat(value as string)); break;
-      case 'withdrawRate':
-        setWithdrawRate(round2(parseFloat(value as string)));
+      case 'withdrawRate': {
+        const newRate = round2(parseFloat(value as string));
+        setWithdrawRate(newRate);
+        setInitialWithdrawalAmount(Math.round(activeStartBalance * (newRate / 100)));
         break;
-      case 'initialWithdrawalAmount':
-        setInitialWithdrawalAmount(parseFloat(value as string));
+      }
+      case 'initialWithdrawalAmount': {
+        const newAmount = parseFloat(value as string);
+        setInitialWithdrawalAmount(newAmount);
+        setWithdrawRate(round2((newAmount / activeStartBalance) * 100));
         break;
+      }
       case 'inflationAdjust': setInflationAdjust(value as boolean); break;
       case 'inflationRate': setInflationRate(parseFloat(value as string)); break;
       case 'mode': setMode(value as "actual-seq" | "actual-seq-random-start" | "random-shuffle" | "bootstrap"); break;
@@ -83,14 +89,14 @@ export default function App() {
 
   // Effect to update EITHER initialWithdrawalAmount OR withdrawRate if startBalance changes.
   useEffect(() => {
-    if (isInitialAmountLocked) {
-      // If locked, initial withdrawal amount is king. Recalculate rate.
+    if (!isInitialAmountLocked) {
+      // If unlocked, initial withdrawal amount is king. Recalculate rate.
       const newRate = round2((initialWithdrawalAmount / activeStartBalance) * 100);
       if (withdrawRate !== newRate) {
         setWithdrawRate(newRate);
       }
     } else {
-      // If not locked, withdraw rate is king. Recalculate initial amount.
+      // If locked, withdraw rate is king. Recalculate initial amount.
       const newAmount = activeStartBalance * (withdrawRate / 100);
       if (initialWithdrawalAmount !== Math.round(newAmount)) {
         setInitialWithdrawalAmount(Math.round(newAmount));

--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -495,13 +495,14 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
             </label>
             <span className="mt-1 ">=</span>
             <div className={`flex-1 p-2 rounded-lg ${isInitialAmountLocked ? 'bg-green-100' : ''}`}>
-              <label className="block text-sm flex-1">First Widthdraw</label>
+              <label className="block text-sm flex-1">First Withdraw</label>
               <div className="flex items-center mt-1">
                 <input
                   type="number"
                   className={`w-full border rounded-xl p-2 transition-colors ${isInitialAmountLocked ? 'text-green-800 font-semibold' : ''}`}
                   value={Math.round(initialWithdrawalAmount)}
                   step={1000}
+                  disabled={isInitialAmountLocked}
                   onChange={e => onParamChange('initialWithdrawalAmount', Number(e.target.value))} />
                 <button
                   className={`ml-2 text-xl p-1 rounded-full hover:bg-slate-200 transition-colors ${isInitialAmountLocked ? 'opacity-100' : 'opacity-50'}`}

--- a/src/components/Nasdaq100Tab.tsx
+++ b/src/components/Nasdaq100Tab.tsx
@@ -205,13 +205,14 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
             </label>
             <span className="mt-1 ">=</span>
             <div className={`flex-1 p-2 rounded-lg ${isInitialAmountLocked ? 'bg-green-100' : ''}`}>
-              <label className="block text-sm flex-1">First Widthdraw</label>
+              <label className="block text-sm flex-1">First Withdraw</label>
               <div className="flex items-center mt-1">
                 <input
                   type="number"
                   className={`w-full border rounded-xl p-2 transition-colors ${isInitialAmountLocked ? 'text-green-800 font-semibold' : ''}`}
                   value={Math.round(initialWithdrawalAmount)}
                   step={1000}
+                  disabled={isInitialAmountLocked}
                   onChange={e => onParamChange('initialWithdrawalAmount', Number(e.target.value))} />
                 <button
                   className={`ml-2 text-xl p-1 rounded-full hover:bg-slate-200 transition-colors ${isInitialAmountLocked ? 'opacity-100' : 'opacity-50'}`}

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -314,13 +314,14 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
             </label>
             <span className="mt-1 ">=</span>
             <div className={`flex-1 p-2 rounded-lg ${isInitialAmountLocked ? 'bg-green-100' : ''}`}>
-              <label className="block text-sm flex-1">First Widthdraw</label>
+              <label className="block text-sm flex-1">First Withdraw</label>
               <div className="flex items-center mt-1">
                 <input
                   type="number"
                   className={`w-full border rounded-xl p-2 transition-colors ${isInitialAmountLocked ? 'text-green-800 font-semibold' : ''}`}
                   value={Math.round(initialWithdrawalAmount)}
                   step={1000}
+                  disabled={isInitialAmountLocked}
                   onChange={e => onParamChange('initialWithdrawalAmount', Number(e.target.value))} />
                 <button
                   className={`ml-2 text-xl p-1 rounded-full hover:bg-slate-200 transition-colors ${isInitialAmountLocked ? 'opacity-100' : 'opacity-50'}`}

--- a/src/components/S&P500Tab.tsx
+++ b/src/components/S&P500Tab.tsx
@@ -205,13 +205,14 @@ const SPTab: React.FC<SPTabProps> = ({
             </label>
             <span className="mt-1 ">=</span>
             <div className={`flex-1 p-2 rounded-lg ${isInitialAmountLocked ? 'bg-green-100' : ''}`}>
-              <label className="block text-sm flex-1">First Widthdraw</label>
+              <label className="block text-sm flex-1">First Withdraw</label>
               <div className="flex items-center mt-1">
                 <input
                   type="number"
                   className={`w-full border rounded-xl p-2 transition-colors ${isInitialAmountLocked ? 'text-green-800 font-semibold' : ''}`}
                   value={Math.round(initialWithdrawalAmount)}
                   step={1000}
+                  disabled={isInitialAmountLocked}
                   onChange={e => onParamChange('initialWithdrawalAmount', Number(e.target.value))} />
                 <button
                   className={`ml-2 text-xl p-1 rounded-full hover:bg-slate-200 transition-colors ${isInitialAmountLocked ? 'opacity-100' : 'opacity-50'}`}


### PR DESCRIPTION
## Summary
- Keep "First Withdraw" and "% of Starting Portfolio" inputs in sync when unlocked, so edits to either update the other
- Correct "Widthdraw" typo and disable the amount field while locked across all tabs

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run lint`
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a36addbca88324b4da75aff12da4db