### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,7 +176,7 @@ export default function App() {
     localStorage.setItem("activeProfile", p);
   };
 
-  const handleParamChange = (param: string, value: any) => {
+  const handleParamChange = (param: string, value: unknown) => {
     switch (param) {
       case 'startBalance': setStartBalance(parseFloat(value as string)); break;
       case 'cash': setCash(parseFloat(value as string)); break;
@@ -185,10 +185,11 @@ export default function App() {
       case 'bonds': setBonds(parseFloat(value as string)); break;
       case 'allocation':
         if (typeof value === 'object' && value !== null) {
-          setCash(value.cash);
-          setSpy(value.spy);
-          setQqq(value.qqq);
-          setBonds(value.bonds);
+          const alloc = value as { cash: number; spy: number; qqq: number; bonds: number };
+          setCash(alloc.cash);
+          setSpy(alloc.spy);
+          setQqq(alloc.qqq);
+          setBonds(alloc.bonds);
         }
         break;
       case 'drawdownStrategy': setDrawdownStrategy(value as DrawdownStrategy); break;
@@ -266,9 +267,9 @@ export default function App() {
 
   return (
     <div className={darkMode ? "dark" : ""}>
-      <div className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-100 p-6">
+      <div className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-100 p-4 md:p-6">
         <div className="max-w-6xl mx-auto space-y-6">
-          <header className="flex items-center justify-between">
+          <header className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
             <h1 className="text-2xl md:text-3xl font-bold">4% Rule Tester — Monte Carlo</h1>
             <ThemeToggle darkMode={darkMode} toggleDarkMode={() => setDarkMode(prev => !prev)} />
           </header>

--- a/src/components/AllocationSlider.tsx
+++ b/src/components/AllocationSlider.tsx
@@ -7,7 +7,7 @@ interface AllocationSliderProps {
   spy: number;
   qqq: number;
   bonds: number;
-  onParamChange: (param: string, value: any) => void;
+  onParamChange: (param: string, value: unknown) => void;
 }
 
 const AllocationSlider: React.FC<AllocationSliderProps> = ({ cash, spy, qqq, bonds, onParamChange }) => {

--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -46,7 +46,7 @@ interface DrawdownTabProps {
   seed: number | "";
   startYear: number;
   onRefresh: () => void;
-  onParamChange: (param: string, value: any) => void;
+  onParamChange: (param: string, value: unknown) => void;
   setIsInitialAmountLocked: (value: React.SetStateAction<boolean>) => void;
   refreshCounter: number;
   chartStates: Record<string, ChartState>;

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -176,7 +176,7 @@ interface PortfolioTabProps {
   seed: number | "";
   startYear: number;
   onRefresh: () => void;
-  onParamChange: (param: string, value: any) => void;
+  onParamChange: (param: string, value: unknown) => void;
   setIsInitialAmountLocked: (value: React.SetStateAction<boolean>) => void;
   refreshCounter: number;
   chartStates: Record<string, ChartState>;

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -6,36 +6,35 @@ interface TabNavigationProps {
 }
 
 const TabNavigation: React.FC<TabNavigationProps> = ({ activeTab, onTabChange }) => {
+  const baseTabClass =
+    "px-3 sm:px-4 py-2 font-medium text-sm sm:text-base";
+  const activeClass =
+    "text-blue-600 border-b-2 border-blue-600 dark:text-blue-400 dark:border-blue-400";
+  const inactiveClass =
+    "text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200";
+
   return (
-    <div className="flex border-b border-slate-200 dark:border-slate-700 mb-6">
+    <div className="flex overflow-x-auto whitespace-nowrap border-b border-slate-200 dark:border-slate-700 mb-6">
       <button
-        className={`px-4 py-2 font-medium ${activeTab === 'sp500'
-          ? 'text-blue-600 border-b-2 border-blue-600 dark:text-blue-400 dark:border-blue-400'
-          : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}`}
+        className={`${baseTabClass} ${activeTab === 'sp500' ? activeClass : inactiveClass}`}
         onClick={() => onTabChange('sp500')}
       >
         S&P 500
       </button>
       <button
-        className={`px-4 py-2 font-medium ${activeTab === 'nasdaq100'
-          ? 'text-blue-600 border-b-2 border-blue-600 dark:text-blue-400 dark:border-blue-400'
-          : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}`}
+        className={`${baseTabClass} ${activeTab === 'nasdaq100' ? activeClass : inactiveClass}`}
         onClick={() => onTabChange('nasdaq100')}
       >
         NASDAQ 100
       </button>
       <button
-        className={`px-4 py-2 font-medium ${activeTab === 'portfolio'
-          ? 'text-blue-600 border-b-2 border-blue-600 dark:text-blue-400 dark:border-blue-400'
-          : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}`}
+        className={`${baseTabClass} ${activeTab === 'portfolio' ? activeClass : inactiveClass}`}
         onClick={() => onTabChange('portfolio')}
       >
         Portfolio
       </button>
       <button
-        className={`px-4 py-2 font-medium ${activeTab === 'drawdown'
-          ? 'text-blue-600 border-b-2 border-blue-600 dark:text-blue-400 dark:border-blue-400'
-          : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}`}
+        className={`${baseTabClass} ${activeTab === 'drawdown' ? activeClass : inactiveClass}`}
         onClick={() => onTabChange('drawdown')}
       >
         Drawdown Strategies


### PR DESCRIPTION
## Summary
- Make tab navigation scrollable and responsive for small screens
- Adjust header and page padding for better mobile layout
- Replace `any` with `unknown` in several components to satisfy lint

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7d2a1d44c832485704c22ffd0e592