### PR TITLE
Filter minimized chart chips by active tab

### DIFF
--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -738,7 +738,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         </div>
       </section>
 
-      <MinimizedChartsBar chartStates={chartStates} onRestore={toggleMinimize} />
+      <MinimizedChartsBar chartStates={chartStates} onRestore={toggleMinimize} activeTab="drawdown" />
 
       <div className="space-y-6">
         {chartOrder.map((chartId: string) => (

--- a/src/components/MinimizedChartsBar.tsx
+++ b/src/components/MinimizedChartsBar.tsx
@@ -4,10 +4,11 @@ import type { ChartState } from '../App';
 interface MinimizedChartsBarProps {
   chartStates: Record<string, ChartState>;
   onRestore: (chartId: string) => void;
+  activeTab: 'sp500' | 'nasdaq100' | 'portfolio' | 'drawdown';
 }
 
-const MinimizedChartsBar: React.FC<MinimizedChartsBarProps> = ({ chartStates, onRestore }) => {
-  const minimizedCharts = Object.entries(chartStates).filter(([, state]) => state.minimized);
+const MinimizedChartsBar: React.FC<MinimizedChartsBarProps> = ({ chartStates, onRestore, activeTab }) => {
+  const minimizedCharts = Object.entries(chartStates).filter(([, state]) => state.minimized && state.tab === activeTab);
 
   if (minimizedCharts.length === 0) {
     return null;

--- a/src/components/Nasdaq100Tab.tsx
+++ b/src/components/Nasdaq100Tab.tsx
@@ -355,7 +355,7 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
             </div>
         </section>
 
-      <MinimizedChartsBar chartStates={chartStates} onRestore={toggleMinimize} />
+      <MinimizedChartsBar chartStates={chartStates} onRestore={toggleMinimize} activeTab="nasdaq100" />
 
       <div className="space-y-6">
         {chartOrder.map((chartId: string) => (

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -729,7 +729,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
         </div>
       </section>
 
-      <MinimizedChartsBar chartStates={chartStates} onRestore={toggleMinimize} />
+      <MinimizedChartsBar chartStates={chartStates} onRestore={toggleMinimize} activeTab="portfolio" />
 
       <div className="space-y-6">
         {chartOrder.map((chartId: string) => (

--- a/src/components/S&P500Tab.tsx
+++ b/src/components/S&P500Tab.tsx
@@ -355,7 +355,7 @@ const SPTab: React.FC<SPTabProps> = ({
             </div>
         </section>
 
-      <MinimizedChartsBar chartStates={chartStates} onRestore={toggleMinimize} />
+      <MinimizedChartsBar chartStates={chartStates} onRestore={toggleMinimize} activeTab="sp500" />
 
       <div className="space-y-6">
         {chartOrder.map((chartId: string) => (


### PR DESCRIPTION
## Summary
- Prevent minimized chart chips from showing duplicates across tabs by filtering chips for the current tab
- Pass the active tab to the chip bar in each tab component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7d2c7e5308324a21e3b33b9e0d3a3