### PR TITLE
feat: add draggable chart ordering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,6 +140,20 @@ export default function App() {
     drawdown: ["drawdown-trajectory", "drawdown-median-trajectory", "drawdown-median-asset-allocation", "drawdown-asset-allocation", "drawdown-sample"],
   });
 
+  const reorderCharts = (
+    tab: 'sp500' | 'nasdaq100' | 'portfolio' | 'drawdown',
+    sourceId: string,
+    targetId: string,
+  ) => {
+    setChartOrder(prev => {
+      const order = prev[tab].filter(id => id !== sourceId);
+      const targetIndex = order.indexOf(targetId);
+      if (targetIndex === -1) return prev;
+      order.splice(targetIndex, 0, sourceId);
+      return { ...prev, [tab]: order };
+    });
+  };
+
   const toggleMinimize = (chartId: string) => {
     const newChartStates = { ...chartStates };
     newChartStates[chartId].minimized = !newChartStates[chartId].minimized;
@@ -176,7 +190,7 @@ export default function App() {
     localStorage.setItem("activeProfile", p);
   };
 
-  const handleParamChange = (param: string, value: any) => {
+  const handleParamChange = (param: string, value: unknown) => {
     switch (param) {
       case 'startBalance': setStartBalance(parseFloat(value as string)); break;
       case 'cash': setCash(parseFloat(value as string)); break;
@@ -303,6 +317,7 @@ export default function App() {
             chartStates={chartStates}
             toggleMinimize={toggleMinimize}
             chartOrder={chartOrder.sp500}
+            onReorderChart={(source, target) => reorderCharts('sp500', source, target)}
           />
         )}
 
@@ -326,6 +341,7 @@ export default function App() {
             chartStates={chartStates}
             toggleMinimize={toggleMinimize}
             chartOrder={chartOrder.nasdaq100}
+            onReorderChart={(source, target) => reorderCharts('nasdaq100', source, target)}
           />
         )}
 
@@ -354,6 +370,7 @@ export default function App() {
             chartStates={chartStates}
             toggleMinimize={toggleMinimize}
             chartOrder={chartOrder.portfolio}
+            onReorderChart={(source, target) => reorderCharts('portfolio', source, target)}
           />
         )}
 
@@ -382,6 +399,7 @@ export default function App() {
             chartStates={chartStates}
             toggleMinimize={toggleMinimize}
             chartOrder={chartOrder.drawdown}
+            onReorderChart={(source, target) => reorderCharts('drawdown', source, target)}
           />
         )}
         </div>

--- a/src/components/AllocationSlider.tsx
+++ b/src/components/AllocationSlider.tsx
@@ -7,7 +7,7 @@ interface AllocationSliderProps {
   spy: number;
   qqq: number;
   bonds: number;
-  onParamChange: (param: string, value: any) => void;
+  onParamChange: (param: string, value: unknown) => void;
 }
 
 const AllocationSlider: React.FC<AllocationSliderProps> = ({ cash, spy, qqq, bonds, onParamChange }) => {

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -6,13 +6,25 @@ interface ChartProps {
   onMinimize: () => void;
   children: React.ReactNode;
   minimizable: boolean;
+  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
-const Chart: React.FC<ChartProps> = ({ title, onRefresh, onMinimize, children, minimizable }) => {
+const Chart: React.FC<ChartProps> = ({ title, onRefresh, onMinimize, children, minimizable, dragHandleProps }) => {
   return (
     <section className="bg-white dark:bg-slate-800 rounded-2xl shadow p-4 pt-2 h-full">
       <div className="flex items-top justify-between">
-        <h2 className="font-semibold mb-2 pt-2">{title}</h2>
+        <div className="flex items-center">
+          {dragHandleProps && (
+            <div
+              {...dragHandleProps}
+              className={`cursor-move mr-2 pt-2 ${dragHandleProps.className ?? ''}`}
+              aria-label="Drag to reorder"
+            >
+              ☰
+            </div>
+          )}
+          <h2 className="font-semibold mb-2 pt-2">{title}</h2>
+        </div>
         <div className="flex items-top">
           {onRefresh && (
             <button

--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -46,12 +46,13 @@ interface DrawdownTabProps {
   seed: number | "";
   startYear: number;
   onRefresh: () => void;
-  onParamChange: (param: string, value: any) => void;
+  onParamChange: (param: string, value: unknown) => void;
   setIsInitialAmountLocked: (value: React.SetStateAction<boolean>) => void;
   refreshCounter: number;
   chartStates: Record<string, ChartState>;
   toggleMinimize: (chartId: string) => void;
   chartOrder: string[];
+  onReorderChart: (sourceId: string, targetId: string) => void;
 }
 
 import { CAPE_DATA } from "../data/cape";
@@ -80,6 +81,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
   chartStates,
   toggleMinimize,
   chartOrder,
+  onReorderChart,
 }) => {
   const strategy = drawdownWithdrawalStrategy;
   const [guytonKlingerParams, setGuytonKlingerParams] = React.useState({
@@ -501,6 +503,35 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
     }, {} as Record<string, React.ReactNode>),
   };
 
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>, chartId: string) => {
+    e.dataTransfer.setData('text/plain', chartId);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>, targetId: string) => {
+    e.preventDefault();
+    const sourceId = e.dataTransfer.getData('text/plain');
+    if (sourceId && sourceId !== targetId) {
+      onReorderChart(sourceId, targetId);
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+  };
+
+  const renderChart = (chartId: string) => {
+    const element = charts[chartId];
+    return React.isValidElement(element)
+      ? React.cloneElement(element, {
+          dragHandleProps: {
+            draggable: true,
+            onDragStart: (e: React.DragEvent<HTMLDivElement>) => handleDragStart(e, chartId),
+          },
+        })
+      : element;
+  };
+
   return (
     <div className="space-y-6">
       <div className="text-sm text-slate-600 dark:text-slate-400">Data: S&P 500, NASDAQ 100 and 10Y Treasury total return</div>
@@ -742,10 +773,15 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
 
       <div className="space-y-6">
         {chartOrder.map((chartId: string) => (
-          !chartStates[chartId].minimized &&
-          <div key={chartId}>
-            {charts[chartId]}
-          </div>
+          !chartStates[chartId].minimized && (
+            <div
+              key={chartId}
+              onDragOver={handleDragOver}
+              onDrop={(e) => handleDrop(e, chartId)}
+            >
+              {renderChart(chartId)}
+            </div>
+          )
         ))}
       </div>
 

--- a/src/components/S&P500Tab.tsx
+++ b/src/components/S&P500Tab.tsx
@@ -64,6 +64,7 @@ interface SPTabProps {
   chartStates: Record<string, ChartState>;
   toggleMinimize: (chartId: string) => void;
   chartOrder: string[];
+  onReorderChart: (sourceId: string, targetId: string) => void;
 }
 
 const SPTab: React.FC<SPTabProps> = ({
@@ -85,6 +86,7 @@ const SPTab: React.FC<SPTabProps> = ({
   chartStates,
   toggleMinimize,
   chartOrder,
+  onReorderChart,
 }) => {
   const years = useMemo(() => SP500_TOTAL_RETURNS.map(d => d.year).sort((a, b) => a - b), []);
   const availableMultipliers = useMemo(() => SP500_TOTAL_RETURNS.map(d => pctToMult(d.returnPct)), []);
@@ -218,6 +220,35 @@ const SPTab: React.FC<SPTabProps> = ({
         )}
       </Chart>
     ),
+  };
+
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>, chartId: string) => {
+    e.dataTransfer.setData('text/plain', chartId);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>, targetId: string) => {
+    e.preventDefault();
+    const sourceId = e.dataTransfer.getData('text/plain');
+    if (sourceId && sourceId !== targetId) {
+      onReorderChart(sourceId, targetId);
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+  };
+
+  const renderChart = (chartId: string) => {
+    const element = charts[chartId];
+    return React.isValidElement(element)
+      ? React.cloneElement(element, {
+          dragHandleProps: {
+            draggable: true,
+            onDragStart: (e: React.DragEvent<HTMLDivElement>) => handleDragStart(e, chartId),
+          },
+        })
+      : element;
   };
 
   return (
@@ -359,10 +390,15 @@ const SPTab: React.FC<SPTabProps> = ({
 
       <div className="space-y-6">
         {chartOrder.map((chartId: string) => (
-          !chartStates[chartId].minimized &&
-          <div key={chartId}>
-            {charts[chartId]}
-          </div>
+          !chartStates[chartId].minimized && (
+            <div
+              key={chartId}
+              onDragOver={handleDragOver}
+              onDrop={(e) => handleDrop(e, chartId)}
+            >
+              {renderChart(chartId)}
+            </div>
+          )
         ))}
       </div>
 


### PR DESCRIPTION
## Summary
- add drag handle to chart header so charts can be reordered
- implement drag-and-drop logic across tabs and store chart order
- address lint issues with `unknown` types

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7d2f47e9883249a2d9a3c414cd297