### PR TITLE
feat: add chart width toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ export interface ChartState {
   minimized: boolean;
   title: string;
   tab: "sp500" | "nasdaq100" | "portfolio" | "drawdown";
+  size: 'full' | 'half';
 }
 
 export type DrawdownStrategy =
@@ -101,36 +102,36 @@ export default function App() {
   const [refreshCounter, setRefreshCounter] = useState(0);
   const [startYear, setStartYear] = useState<number>(initialProfile.startYear);
   const [chartStates, setChartStates] = useState<Record<string, ChartState>>({
-    "sp500-trajectory": { minimized: false, title: "Portfolio Trajectory Bands", tab: "sp500" },
-    "sp500-sample": { minimized: false, title: "Sample Run Trajectory", tab: "sp500" },
-    "nasdaq100-trajectory": { minimized: false, title: "Portfolio Trajectory Bands", tab: "nasdaq100" },
-    "nasdaq100-sample": { minimized: false, title: "Sample Run Trajectory", tab: "nasdaq100" },
-    "portfolio-trajectory": { minimized: false, title: "Portfolio Trajectory Bands", tab: "portfolio" },
-    "portfolio-median-asset-allocation": { minimized: false, title: "Median Sample Run Asset Allocation", tab: "portfolio" },
-    "portfolio-median-trajectory": { minimized: false, title: "Median Sample Run Trajectory", tab: "portfolio" },
-    "portfolio-asset-allocation": { minimized: false, title: "Sample Run 1 Asset Allocation", tab: "portfolio" },
-    "drawdown-trajectory": { minimized: false, title: "Portfolio Trajectory Bands", tab: "drawdown" },
-    "drawdown-median-asset-allocation": { minimized: false, title: "Median Sample Run Asset Allocation", tab: "drawdown" },
-    "drawdown-median-trajectory": { minimized: false, title: "Median Sample Run Trajectory", tab: "drawdown" },
-    "drawdown-asset-allocation": { minimized: false, title: "Sample Run 1 Asset Allocation", tab: "drawdown" },
-    "portfolio-sample-2-asset-allocation": { minimized: true, title: "Sample Run 2 Asset Allocation", tab: "portfolio" },
-    "portfolio-sample-3-asset-allocation": { minimized: true, title: "Sample Run 3 Asset Allocation", tab: "portfolio" },
-    "portfolio-sample-4-asset-allocation": { minimized: true, title: "Sample Run 4 Asset Allocation", tab: "portfolio" },
-    "portfolio-sample-5-asset-allocation": { minimized: true, title: "Sample Run 5 Asset Allocation", tab: "portfolio" },
-    "portfolio-sample": { minimized: false, title: "Sample Run 1 Trajectory", tab: "portfolio" },
-    "portfolio-sample-2-trajectory": { minimized: true, title: "Sample Run 2 Trajectory", tab: "portfolio" },
-    "portfolio-sample-3-trajectory": { minimized: true, title: "Sample Run 3 Trajectory", tab: "portfolio" },
-    "portfolio-sample-4-trajectory": { minimized: true, title: "Sample Run 4 Trajectory", tab: "portfolio" },
-    "portfolio-sample-5-trajectory": { minimized: true, title: "Sample Run 5 Trajectory", tab: "portfolio" },
-    "drawdown-sample": { minimized: false, title: "Sample Run 1 Trajectory", tab: "drawdown" },
-    "drawdown-sample-2-asset-allocation": { minimized: true, title: "Sample Run 2 Asset Allocation", tab: "drawdown" },
-    "drawdown-sample-3-asset-allocation": { minimized: true, title: "Sample Run 3 Asset Allocation", tab: "drawdown" },
-    "drawdown-sample-4-asset-allocation": { minimized: true, title: "Sample Run 4 Asset Allocation", tab: "drawdown" },
-    "drawdown-sample-5-asset-allocation": { minimized: true, title: "Sample Run 5 Asset Allocation", tab: "drawdown" },
-    "drawdown-sample-2-trajectory": { minimized: true, title: "Sample Run 2 Trajectory", tab: "drawdown" },
-    "drawdown-sample-3-trajectory": { minimized: true, title: "Sample Run 3 Trajectory", tab: "drawdown" },
-    "drawdown-sample-4-trajectory": { minimized: true, title: "Sample Run 4 Trajectory", tab: "drawdown" },
-    "drawdown-sample-5-trajectory": { minimized: true, title: "Sample Run 5 Trajectory", tab: "drawdown" },
+    "sp500-trajectory": { minimized: false, title: "Portfolio Trajectory Bands", tab: "sp500", size: 'full' },
+    "sp500-sample": { minimized: false, title: "Sample Run Trajectory", tab: "sp500", size: 'half' },
+    "nasdaq100-trajectory": { minimized: false, title: "Portfolio Trajectory Bands", tab: "nasdaq100", size: 'full' },
+    "nasdaq100-sample": { minimized: false, title: "Sample Run Trajectory", tab: "nasdaq100", size: 'half' },
+    "portfolio-trajectory": { minimized: false, title: "Portfolio Trajectory Bands", tab: "portfolio", size: 'full' },
+    "portfolio-median-asset-allocation": { minimized: false, title: "Median Sample Run Asset Allocation", tab: "portfolio", size: 'half' },
+    "portfolio-median-trajectory": { minimized: false, title: "Median Sample Run Trajectory", tab: "portfolio", size: 'full' },
+    "portfolio-asset-allocation": { minimized: false, title: "Sample Run 1 Asset Allocation", tab: "portfolio", size: 'half' },
+    "drawdown-trajectory": { minimized: false, title: "Portfolio Trajectory Bands", tab: "drawdown", size: 'full' },
+    "drawdown-median-asset-allocation": { minimized: false, title: "Median Sample Run Asset Allocation", tab: "drawdown", size: 'half' },
+    "drawdown-median-trajectory": { minimized: false, title: "Median Sample Run Trajectory", tab: "drawdown", size: 'full' },
+    "drawdown-asset-allocation": { minimized: false, title: "Sample Run 1 Asset Allocation", tab: "drawdown", size: 'half' },
+    "portfolio-sample-2-asset-allocation": { minimized: true, title: "Sample Run 2 Asset Allocation", tab: "portfolio", size: 'half' },
+    "portfolio-sample-3-asset-allocation": { minimized: true, title: "Sample Run 3 Asset Allocation", tab: "portfolio", size: 'half' },
+    "portfolio-sample-4-asset-allocation": { minimized: true, title: "Sample Run 4 Asset Allocation", tab: "portfolio", size: 'half' },
+    "portfolio-sample-5-asset-allocation": { minimized: true, title: "Sample Run 5 Asset Allocation", tab: "portfolio", size: 'half' },
+    "portfolio-sample": { minimized: false, title: "Sample Run 1 Trajectory", tab: "portfolio", size: 'half' },
+    "portfolio-sample-2-trajectory": { minimized: true, title: "Sample Run 2 Trajectory", tab: "portfolio", size: 'half' },
+    "portfolio-sample-3-trajectory": { minimized: true, title: "Sample Run 3 Trajectory", tab: "portfolio", size: 'half' },
+    "portfolio-sample-4-trajectory": { minimized: true, title: "Sample Run 4 Trajectory", tab: "portfolio", size: 'half' },
+    "portfolio-sample-5-trajectory": { minimized: true, title: "Sample Run 5 Trajectory", tab: "portfolio", size: 'half' },
+    "drawdown-sample": { minimized: false, title: "Sample Run 1 Trajectory", tab: "drawdown", size: 'half' },
+    "drawdown-sample-2-asset-allocation": { minimized: true, title: "Sample Run 2 Asset Allocation", tab: "drawdown", size: 'half' },
+    "drawdown-sample-3-asset-allocation": { minimized: true, title: "Sample Run 3 Asset Allocation", tab: "drawdown", size: 'half' },
+    "drawdown-sample-4-asset-allocation": { minimized: true, title: "Sample Run 4 Asset Allocation", tab: "drawdown", size: 'half' },
+    "drawdown-sample-5-asset-allocation": { minimized: true, title: "Sample Run 5 Asset Allocation", tab: "drawdown", size: 'half' },
+    "drawdown-sample-2-trajectory": { minimized: true, title: "Sample Run 2 Trajectory", tab: "drawdown", size: 'half' },
+    "drawdown-sample-3-trajectory": { minimized: true, title: "Sample Run 3 Trajectory", tab: "drawdown", size: 'half' },
+    "drawdown-sample-4-trajectory": { minimized: true, title: "Sample Run 4 Trajectory", tab: "drawdown", size: 'half' },
+    "drawdown-sample-5-trajectory": { minimized: true, title: "Sample Run 5 Trajectory", tab: "drawdown", size: 'half' },
   });
 
   const [chartOrder, setChartOrder] = useState<Record<string, string[]>>({
@@ -151,6 +152,13 @@ export default function App() {
       const newOrder = [chartId, ...order.filter(id => id !== chartId)];
       setChartOrder(prev => ({ ...prev, [tab]: newOrder }));
     }
+  };
+
+  const toggleSize = (chartId: string) => {
+    setChartStates(prev => ({
+      ...prev,
+      [chartId]: { ...prev[chartId], size: prev[chartId].size === 'half' ? 'full' : 'half' },
+    }));
   };
 
   const handleProfileChange = (p: Profile) => {
@@ -303,6 +311,7 @@ export default function App() {
             refreshCounter={refreshCounter}
             chartStates={chartStates}
             toggleMinimize={toggleMinimize}
+            toggleSize={toggleSize}
             chartOrder={chartOrder.sp500}
           />
         )}
@@ -326,6 +335,7 @@ export default function App() {
             refreshCounter={refreshCounter}
             chartStates={chartStates}
             toggleMinimize={toggleMinimize}
+            toggleSize={toggleSize}
             chartOrder={chartOrder.nasdaq100}
           />
         )}
@@ -354,6 +364,7 @@ export default function App() {
             refreshCounter={refreshCounter}
             chartStates={chartStates}
             toggleMinimize={toggleMinimize}
+            toggleSize={toggleSize}
             chartOrder={chartOrder.portfolio}
           />
         )}
@@ -382,6 +393,7 @@ export default function App() {
             refreshCounter={refreshCounter}
             chartStates={chartStates}
             toggleMinimize={toggleMinimize}
+            toggleSize={toggleSize}
             chartOrder={chartOrder.drawdown}
           />
         )}

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -6,11 +6,13 @@ interface ChartProps {
   title: string;
   onRefresh?: () => void;
   onMinimize: () => void;
+  onToggleSize: () => void;
+  size: 'full' | 'half';
   children: React.ReactNode;
   minimizable: boolean;
 }
 
-const Chart: React.FC<ChartProps> = ({ chartId, title, onRefresh, onMinimize, children, minimizable }) => {
+const Chart: React.FC<ChartProps> = ({ chartId, title, onRefresh, onMinimize, onToggleSize, size, children, minimizable }) => {
   const { chart: colorClass } = getChartColor(chartId);
   return (
     <section className={`bg-white dark:bg-slate-800 rounded-2xl shadow p-4 pt-2 h-full border-l-4 ${colorClass}`}>
@@ -27,6 +29,14 @@ const Chart: React.FC<ChartProps> = ({ chartId, title, onRefresh, onMinimize, ch
               ⟳
             </button>
           )}
+          <button
+            className="text-m hover:bg-slate-100 dark:hover:bg-slate-700 rounded-full w-8 h-8 flex items-center justify-center transition-colors"
+            onClick={onToggleSize}
+            aria-label={size === 'half' ? 'Expand chart' : 'Shrink chart'}
+            title={size === 'half' ? 'Expand chart' : 'Shrink chart'}
+          >
+            {size === 'half' ? '⤢' : '⤡'}
+          </button>
           {minimizable && (
             <button
               className="text-m hover:bg-slate-100 dark:hover:bg-slate-700 rounded-full w-8 h-8 flex items-center justify-center transition-colors"

--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -51,6 +51,7 @@ interface DrawdownTabProps {
   refreshCounter: number;
   chartStates: Record<string, ChartState>;
   toggleMinimize: (chartId: string) => void;
+  toggleSize: (chartId: string) => void;
   chartOrder: string[];
 }
 
@@ -79,6 +80,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
   refreshCounter,
   chartStates,
   toggleMinimize,
+  toggleSize,
   chartOrder,
 }) => {
   const strategy = drawdownWithdrawalStrategy;
@@ -245,6 +247,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         title={chartStates['drawdown-trajectory'].title}
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('drawdown-trajectory')}
+        onToggleSize={() => toggleSize('drawdown-trajectory')}
+        size={chartStates['drawdown-trajectory'].size}
         minimizable={true}
       >
         {stats && (
@@ -273,6 +277,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         title={chartStates['drawdown-median-asset-allocation'].title}
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('drawdown-median-asset-allocation')}
+        onToggleSize={() => toggleSize('drawdown-median-asset-allocation')}
+        size={chartStates['drawdown-median-asset-allocation'].size}
         minimizable={true}
       >
         {stats?.medianRun && (
@@ -310,6 +316,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         title={chartStates['drawdown-median-trajectory'].title}
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('drawdown-median-trajectory')}
+        onToggleSize={() => toggleSize('drawdown-median-trajectory')}
+        size={chartStates['drawdown-median-trajectory'].size}
         minimizable={true}
       >
         {stats?.medianRun && (
@@ -348,6 +356,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         title={chartStates['drawdown-asset-allocation'].title}
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('drawdown-asset-allocation')}
+        onToggleSize={() => toggleSize('drawdown-asset-allocation')}
+        size={chartStates['drawdown-asset-allocation'].size}
         minimizable={true}
       >
         {sampleRun && (
@@ -385,6 +395,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         title={chartStates['drawdown-sample'].title}
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('drawdown-sample')}
+        onToggleSize={() => toggleSize('drawdown-sample')}
+        size={chartStates['drawdown-sample'].size}
         minimizable={true}
       >
         {sampleRun && (
@@ -439,6 +451,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
           title={chartStates[`drawdown-sample-${i}-asset-allocation`].title}
           onRefresh={onRefresh}
           onMinimize={() => toggleMinimize(`drawdown-sample-${i}-asset-allocation`)}
+          onToggleSize={() => toggleSize(`drawdown-sample-${i}-asset-allocation`)}
+          size={chartStates[`drawdown-sample-${i}-asset-allocation`].size}
           minimizable={true}
         >
           <div className="h-72">
@@ -474,6 +488,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
           title={chartStates[`drawdown-sample-${i}-trajectory`].title}
           onRefresh={onRefresh}
           onMinimize={() => toggleMinimize(`drawdown-sample-${i}-trajectory`)}
+          onToggleSize={() => toggleSize(`drawdown-sample-${i}-trajectory`)}
+          size={chartStates[`drawdown-sample-${i}-trajectory`].size}
           minimizable={true}
         >
           <div className="h-72">
@@ -747,12 +763,13 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
 
       <MinimizedChartsBar chartStates={chartStates} onRestore={toggleMinimize} activeTab="drawdown" />
 
-      <div className="space-y-6">
+      <div className="grid md:grid-cols-2 gap-6">
         {chartOrder.map((chartId: string) => (
-          !chartStates[chartId].minimized &&
-          <div key={chartId}>
-            {charts[chartId]}
-          </div>
+          !chartStates[chartId].minimized && (
+            <div key={chartId} className={chartStates[chartId].size === 'full' ? 'md:col-span-2' : ''}>
+              {charts[chartId]}
+            </div>
+          )
         ))}
       </div>
 

--- a/src/components/Nasdaq100Tab.tsx
+++ b/src/components/Nasdaq100Tab.tsx
@@ -63,6 +63,7 @@ interface NasdaqTabProps {
   refreshCounter: number;
   chartStates: Record<string, ChartState>;
   toggleMinimize: (chartId: string) => void;
+  toggleSize: (chartId: string) => void;
   chartOrder: string[];
 }
 
@@ -84,6 +85,7 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
   refreshCounter,
   chartStates,
   toggleMinimize,
+  toggleSize,
   chartOrder,
 }) => {
   const years = useMemo(() => NASDAQ100_TOTAL_RETURNS.map(d => d.year).sort((a, b) => a - b), []);
@@ -160,6 +162,8 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
         title="Portfolio Trajectory Bands"
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('nasdaq100-trajectory')}
+        onToggleSize={() => toggleSize('nasdaq100-trajectory')}
+        size={chartStates['nasdaq100-trajectory'].size}
         minimizable={true}
       >
         {stats && (
@@ -188,6 +192,8 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
         title="Sample Run Trajectory"
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('nasdaq100-sample')}
+        onToggleSize={() => toggleSize('nasdaq100-sample')}
+        size={chartStates['nasdaq100-sample'].size}
         minimizable={true}
       >
         {sampleRun && (
@@ -359,12 +365,13 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
 
       <MinimizedChartsBar chartStates={chartStates} onRestore={toggleMinimize} activeTab="nasdaq100" />
 
-      <div className="space-y-6">
+      <div className="grid md:grid-cols-2 gap-6">
         {chartOrder.map((chartId: string) => (
-          !chartStates[chartId].minimized &&
-          <div key={chartId}>
-            {charts[chartId]}
-          </div>
+          !chartStates[chartId].minimized && (
+            <div key={chartId} className={chartStates[chartId].size === 'full' ? 'md:col-span-2' : ''}>
+              {charts[chartId]}
+            </div>
+          )
         ))}
       </div>
 

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -181,6 +181,7 @@ interface PortfolioTabProps {
   refreshCounter: number;
   chartStates: Record<string, ChartState>;
   toggleMinimize: (chartId: string) => void;
+  toggleSize: (chartId: string) => void;
   chartOrder: string[];
 }
 
@@ -207,6 +208,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
   refreshCounter,
   chartStates,
   toggleMinimize,
+  toggleSize,
   chartOrder,
 }) => {
   const currency = new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 });
@@ -324,6 +326,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
         title={chartStates['portfolio-trajectory'].title}
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('portfolio-trajectory')}
+        onToggleSize={() => toggleSize('portfolio-trajectory')}
+        size={chartStates['portfolio-trajectory'].size}
         minimizable={true}
       >
         {stats && (
@@ -352,6 +356,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
         title={chartStates['portfolio-median-asset-allocation'].title}
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('portfolio-median-asset-allocation')}
+        onToggleSize={() => toggleSize('portfolio-median-asset-allocation')}
+        size={chartStates['portfolio-median-asset-allocation'].size}
         minimizable={true}
       >
         {stats?.medianRun && (
@@ -389,6 +395,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
         title={chartStates['portfolio-median-trajectory'].title}
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('portfolio-median-trajectory')}
+        onToggleSize={() => toggleSize('portfolio-median-trajectory')}
+        size={chartStates['portfolio-median-trajectory'].size}
         minimizable={true}
       >
         {stats?.medianRun && (
@@ -427,6 +435,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
         title={chartStates['portfolio-asset-allocation'].title}
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('portfolio-asset-allocation')}
+        onToggleSize={() => toggleSize('portfolio-asset-allocation')}
+        size={chartStates['portfolio-asset-allocation'].size}
         minimizable={true}
       >
         {sampleRun && (
@@ -464,6 +474,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
         title={chartStates['portfolio-sample'].title}
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('portfolio-sample')}
+        onToggleSize={() => toggleSize('portfolio-sample')}
+        size={chartStates['portfolio-sample'].size}
         minimizable={true}
       >
         {sampleRun && (
@@ -505,6 +517,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
           title={chartStates[`portfolio-sample-${i}-asset-allocation`].title}
           onRefresh={onRefresh}
           onMinimize={() => toggleMinimize(`portfolio-sample-${i}-asset-allocation`)}
+          onToggleSize={() => toggleSize(`portfolio-sample-${i}-asset-allocation`)}
+          size={chartStates[`portfolio-sample-${i}-asset-allocation`].size}
           minimizable={true}
         >
           <div className="h-72">
@@ -540,6 +554,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
           title={chartStates[`portfolio-sample-${i}-trajectory`].title}
           onRefresh={onRefresh}
           onMinimize={() => toggleMinimize(`portfolio-sample-${i}-trajectory`)}
+          onToggleSize={() => toggleSize(`portfolio-sample-${i}-trajectory`)}
+          size={chartStates[`portfolio-sample-${i}-trajectory`].size}
           minimizable={true}
         >
           <div className="h-72">
@@ -738,12 +754,13 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
 
       <MinimizedChartsBar chartStates={chartStates} onRestore={toggleMinimize} activeTab="portfolio" />
 
-      <div className="space-y-6">
+      <div className="grid md:grid-cols-2 gap-6">
         {chartOrder.map((chartId: string) => (
-          !chartStates[chartId].minimized &&
-          <div key={chartId}>
-            {charts[chartId]}
-          </div>
+          !chartStates[chartId].minimized && (
+            <div key={chartId} className={chartStates[chartId].size === 'full' ? 'md:col-span-2' : ''}>
+              {charts[chartId]}
+            </div>
+          )
         ))}
       </div>
 

--- a/src/components/S&P500Tab.tsx
+++ b/src/components/S&P500Tab.tsx
@@ -63,6 +63,7 @@ interface SPTabProps {
   refreshCounter: number;
   chartStates: Record<string, ChartState>;
   toggleMinimize: (chartId: string) => void;
+  toggleSize: (chartId: string) => void;
   chartOrder: string[];
 }
 
@@ -84,6 +85,7 @@ const SPTab: React.FC<SPTabProps> = ({
   refreshCounter,
   chartStates,
   toggleMinimize,
+  toggleSize,
   chartOrder,
 }) => {
   const years = useMemo(() => SP500_TOTAL_RETURNS.map(d => d.year).sort((a, b) => a - b), []);
@@ -160,6 +162,8 @@ const SPTab: React.FC<SPTabProps> = ({
         title="Portfolio Trajectory Bands"
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('sp500-trajectory')}
+        onToggleSize={() => toggleSize('sp500-trajectory')}
+        size={chartStates['sp500-trajectory'].size}
         minimizable={true}
       >
         {stats && (
@@ -188,6 +192,8 @@ const SPTab: React.FC<SPTabProps> = ({
         title="Sample Run Trajectory"
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('sp500-sample')}
+        onToggleSize={() => toggleSize('sp500-sample')}
+        size={chartStates['sp500-sample'].size}
         minimizable={true}
       >
         {sampleRun && (
@@ -359,12 +365,13 @@ const SPTab: React.FC<SPTabProps> = ({
 
       <MinimizedChartsBar chartStates={chartStates} onRestore={toggleMinimize} activeTab="sp500" />
 
-      <div className="space-y-6">
+      <div className="grid md:grid-cols-2 gap-6">
         {chartOrder.map((chartId: string) => (
-          !chartStates[chartId].minimized &&
-          <div key={chartId}>
-            {charts[chartId]}
-          </div>
+          !chartStates[chartId].minimized && (
+            <div key={chartId} className={chartStates[chartId].size === 'full' ? 'md:col-span-2' : ''}>
+              {charts[chartId]}
+            </div>
+          )
         ))}
       </div>
 


### PR DESCRIPTION
## Summary
- add chart resize button to expand or shrink chart width
- default asset allocation and sample trajectory charts to half width
- arrange charts on a responsive two-column grid

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8d2d3d4e08324988b6d990e272aef