### PR TITLE
feat: use light red for QQQ

### DIFF
--- a/src/components/AllocationSlider.tsx
+++ b/src/components/AllocationSlider.tsx
@@ -56,14 +56,14 @@ const AllocationSlider: React.FC<AllocationSliderProps> = ({ cash, spy, qqq, bit
         trackStyle={[
           { backgroundColor: '#8884d8' }, // Cash
           { backgroundColor: '#82ca9d' }, // SPY
-          { backgroundColor: '#ffc658' }, // QQQ
+          { backgroundColor: '#ff7f7f' }, // QQQ
           { backgroundColor: '#f2a900' }  // Bitcoin
         ]}
         handleStyle={[
             { display: 'none' }, // Handle at 0
             { backgroundColor: '#8884d8', border: '2px solid white', boxShadow: '0 0 0 2px #6f6af2' },
             { backgroundColor: '#82ca9d', border: '2px solid white', boxShadow: '0 0 0 2px #6ac189' },
-            { backgroundColor: '#ffc658', border: '2px solid white', boxShadow: '0 0 0 2px #e5b24f' },
+            { backgroundColor: '#ff7f7f', border: '2px solid white', boxShadow: '0 0 0 2px #e56767' },
             { backgroundColor: '#f2a900', border: '2px solid white', boxShadow: '0 0 0 2px #d18e00' }]}
         railStyle={{ backgroundColor: '#95a5a6' }} // Bonds
       />
@@ -77,7 +77,7 @@ const AllocationSlider: React.FC<AllocationSliderProps> = ({ cash, spy, qqq, bit
           <span>SPY ({spyPct.toFixed(1)}%)</span>
         </div>
         <div className="flex items-center space-x-1">
-          <div className="w-3 h-3 rounded-full" style={{ backgroundColor: '#ffc658' }}></div>
+          <div className="w-3 h-3 rounded-full" style={{ backgroundColor: '#ff7f7f' }}></div>
           <span>QQQ ({qqqPct.toFixed(1)}%)</span>
         </div>
         <div className="flex items-center space-x-1">

--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -312,7 +312,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
                 <Legend />
                 <Area type="monotone" dataKey="cash" name="Cash" stackId="1" stroke="#8884d8" fill="#8884d8" />
                 <Area type="monotone" dataKey="spy" name="SPY" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
-                <Area type="monotone" dataKey="qqq" name="QQQ" stackId="1" stroke="#ffc658" fill="#ffc658" />
+                <Area type="monotone" dataKey="qqq" name="QQQ" stackId="1" stroke="#ff7f7f" fill="#ff7f7f" />
                 <Area type="monotone" dataKey="bitcoin" name="Bitcoin" stackId="1" stroke="#f2a900" fill="#f2a900" />
                 <Area type="monotone" dataKey="bonds" name="Bonds" stackId="1" stroke="#95a5a6" fill="#95a5a6" />
               </AreaChart>
@@ -392,7 +392,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
                 <Legend />
                 <Area type="monotone" dataKey="cash" name="Cash" stackId="1" stroke="#8884d8" fill="#8884d8" />
                 <Area type="monotone" dataKey="spy" name="SPY" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
-                <Area type="monotone" dataKey="qqq" name="QQQ" stackId="1" stroke="#ffc658" fill="#ffc658" />
+                <Area type="monotone" dataKey="qqq" name="QQQ" stackId="1" stroke="#ff7f7f" fill="#ff7f7f" />
                 <Area type="monotone" dataKey="bitcoin" name="Bitcoin" stackId="1" stroke="#f2a900" fill="#f2a900" />
                 <Area type="monotone" dataKey="bonds" name="Bonds" stackId="1" stroke="#ff8042" fill="#ff8042" />
               </AreaChart>
@@ -487,7 +487,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
                 <Legend />
                 <Area type="monotone" dataKey="cash" name="Cash" stackId="1" stroke="#8884d8" fill="#8884d8" />
                 <Area type="monotone" dataKey="spy" name="SPY" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
-                <Area type="monotone" dataKey="qqq" name="QQQ" stackId="1" stroke="#ffc658" fill="#ffc658" />
+                <Area type="monotone" dataKey="qqq" name="QQQ" stackId="1" stroke="#ff7f7f" fill="#ff7f7f" />
                 <Area type="monotone" dataKey="bitcoin" name="Bitcoin" stackId="1" stroke="#f2a900" fill="#f2a900" />
                 <Area type="monotone" dataKey="bonds" name="Bonds" stackId="1" stroke="#95a5a6" fill="#95a5a6" />
               </AreaChart>

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -409,7 +409,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
                 <Legend />
                 <Area type="monotone" dataKey="cash" name="Cash" stackId="1" stroke="#8884d8" fill="#8884d8" />
                 <Area type="monotone" dataKey="spy" name="SPY" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
-                <Area type="monotone" dataKey="qqq" name="QQQ" stackId="1" stroke="#ffc658" fill="#ffc658" />
+                <Area type="monotone" dataKey="qqq" name="QQQ" stackId="1" stroke="#ff7f7f" fill="#ff7f7f" />
                 <Area type="monotone" dataKey="bitcoin" name="Bitcoin" stackId="1" stroke="#f2a900" fill="#f2a900" />
                 <Area type="monotone" dataKey="bonds" name="Bonds" stackId="1" stroke="#95a5a6" fill="#95a5a6" />
               </AreaChart>
@@ -489,7 +489,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
                 <Legend />
                 <Area type="monotone" dataKey="cash" name="Cash" stackId="1" stroke="#8884d8" fill="#8884d8" />
                 <Area type="monotone" dataKey="spy" name="SPY" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
-                <Area type="monotone" dataKey="qqq" name="QQQ" stackId="1" stroke="#ffc658" fill="#ffc658" />
+                <Area type="monotone" dataKey="qqq" name="QQQ" stackId="1" stroke="#ff7f7f" fill="#ff7f7f" />
                 <Area type="monotone" dataKey="bitcoin" name="Bitcoin" stackId="1" stroke="#f2a900" fill="#f2a900" />
                 <Area type="monotone" dataKey="bonds" name="Bonds" stackId="1" stroke="#95a5a6" fill="#95a5a6" />
               </AreaChart>
@@ -571,7 +571,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
                 <Legend />
                 <Area type="monotone" dataKey="cash" name="Cash" stackId="1" stroke="#8884d8" fill="#8884d8" />
                 <Area type="monotone" dataKey="spy" name="SPY" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
-                <Area type="monotone" dataKey="qqq" name="QQQ" stackId="1" stroke="#ffc658" fill="#ffc658" />
+                <Area type="monotone" dataKey="qqq" name="QQQ" stackId="1" stroke="#ff7f7f" fill="#ff7f7f" />
                 <Area type="monotone" dataKey="bitcoin" name="Bitcoin" stackId="1" stroke="#f2a900" fill="#f2a900" />
                 <Area type="monotone" dataKey="bonds" name="Bonds" stackId="1" stroke="#95a5a6" fill="#95a5a6" />
               </AreaChart>


### PR DESCRIPTION
## Summary
- restyle QQQ allocation slider handle and legend using light red
- apply light red QQQ area to asset allocation charts

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acd34321fc8324914b8f20b554552a