### PR TITLE
feat: add data tab with yearly inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Bucket Retirement Calculator tests the classic 4% retirement withdrawal rule acr
 ## Live Demo
 
 The latest build is available at [bucket-retirement-calculator.vercel.app](https://bucket-retirement-calculator.vercel.app/).
+See the [Data tab](https://bucket-retirement-calculator.vercel.app/#data) for the raw yearly inputs.
 
 ## Features
 
@@ -34,7 +35,7 @@ Open the URL printed by the dev command in your browser to explore the app.
 
 ## Data
 
-Historical index data is sourced from Robert Shiller's *ie_data.xls* dataset included in the repository.
+Historical index data is sourced from Robert Shiller's *ie_data.xls* dataset included in the repository and spans 1881–2025. See the [Data tab](https://bucket-retirement-calculator.vercel.app/#data) for a full table of yearly values.
 
 ## License
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import PortfolioTab from "./components/PortfolioTab";
 import DrawdownTab from "./components/DrawdownTab";
 import ProfileSelector, { type Profile } from "./components/ProfileSelector";
 import ThemeToggle from "./components/ThemeToggle";
+import DataTab from "./components/DataTab";
 
 export interface ChartState {
   minimized: boolean;
@@ -38,7 +39,31 @@ export type DrawdownStrategies =
 export default function App() {
   const round2 = (n: number) => Math.round(n * 100) / 100;
   const [darkMode, setDarkMode] = usePersistentState("darkMode", false);
-  const [activeTab, setActiveTab] = useState<"sp500" | "nasdaq100" | "portfolio" | "drawdown">("sp500");
+  const [activeTab, setActiveTab] = useState<
+    "sp500" | "nasdaq100" | "portfolio" | "drawdown" | "data"
+  >("sp500");
+
+  useEffect(() => {
+    const handleHashChange = () => {
+      const hash = window.location.hash.replace('#', '');
+      if (
+        hash === 'sp500' ||
+        hash === 'nasdaq100' ||
+        hash === 'portfolio' ||
+        hash === 'drawdown' ||
+        hash === 'data'
+      ) {
+        setActiveTab(hash as typeof activeTab);
+      }
+    };
+    handleHashChange();
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
+  useEffect(() => {
+    window.location.hash = activeTab;
+  }, [activeTab]);
 
   const years = useMemo(() => {
     const spyYears = new Set(SP500_TOTAL_RETURNS.map(d => d.year));
@@ -406,6 +431,7 @@ export default function App() {
             chartOrder={chartOrder.drawdown}
           />
         )}
+        {activeTab === 'data' && <DataTab />}
         </div>
       </div>
     </div>

--- a/src/components/DataTab.tsx
+++ b/src/components/DataTab.tsx
@@ -1,0 +1,70 @@
+import { useMemo } from "react";
+import { SP500_TOTAL_RETURNS, NASDAQ100_TOTAL_RETURNS, BITCOIN_TOTAL_RETURNS } from "../data/returns";
+import { TEN_YEAR_TREASURY_TOTAL_RETURNS } from "../data/bonds";
+import { INFLATION_RATES } from "../data/inflation";
+import { CAPE_DATA } from "../data/cape";
+
+export default function DataTab() {
+  const years = useMemo(() => {
+    return Array.from(
+      new Set([
+        ...SP500_TOTAL_RETURNS.map(d => d.year),
+        ...NASDAQ100_TOTAL_RETURNS.map(d => d.year),
+        ...BITCOIN_TOTAL_RETURNS.map(d => d.year),
+        ...TEN_YEAR_TREASURY_TOTAL_RETURNS.map(d => d.year),
+        ...INFLATION_RATES.map(d => d.year),
+        ...Object.keys(CAPE_DATA).map(Number),
+      ])
+    ).sort((a, b) => a - b);
+  }, []);
+
+  const rows = useMemo(() => years.map(year => ({
+    year,
+    sp500: SP500_TOTAL_RETURNS.find(d => d.year === year)?.returnPct ?? null,
+    nasdaq100: NASDAQ100_TOTAL_RETURNS.find(d => d.year === year)?.returnPct ?? null,
+    bitcoin: BITCOIN_TOTAL_RETURNS.find(d => d.year === year)?.returnPct ?? null,
+    bonds: TEN_YEAR_TREASURY_TOTAL_RETURNS.find(d => d.year === year)?.returnPct ?? null,
+    inflation: INFLATION_RATES.find(d => d.year === year)?.inflationPct ?? null,
+    cape: CAPE_DATA[year] ?? null,
+  })), [years]);
+
+  const minYear = years[0];
+  const maxYear = years[years.length - 1];
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm">
+        Annual returns and metrics used for simulations. Data spans {minYear}–{maxYear}.
+      </p>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="sticky top-0 bg-white dark:bg-slate-800">
+            <tr>
+              <th className="px-2 py-1 text-left">Year</th>
+              <th className="px-2 py-1 text-right">S&amp;P 500</th>
+              <th className="px-2 py-1 text-right">NASDAQ 100</th>
+              <th className="px-2 py-1 text-right">Bitcoin</th>
+              <th className="px-2 py-1 text-right">10Y Treasury</th>
+              <th className="px-2 py-1 text-right">Inflation</th>
+              <th className="px-2 py-1 text-right">CAPE</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(r => (
+              <tr key={r.year} className="border-b border-slate-200 dark:border-slate-700">
+                <td className="px-2 py-1 text-left">{r.year}</td>
+                <td className="px-2 py-1 text-right">{r.sp500 != null ? r.sp500.toFixed(2) : "–"}</td>
+                <td className="px-2 py-1 text-right">{r.nasdaq100 != null ? r.nasdaq100.toFixed(2) : "–"}</td>
+                <td className="px-2 py-1 text-right">{r.bitcoin != null ? r.bitcoin.toFixed(2) : "–"}</td>
+                <td className="px-2 py-1 text-right">{r.bonds != null ? r.bonds.toFixed(2) : "–"}</td>
+                <td className="px-2 py-1 text-right">{r.inflation != null ? r.inflation.toFixed(2) : "–"}</td>
+                <td className="px-2 py-1 text-right">{r.cape != null ? r.cape.toFixed(2) : "–"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/DataTab.tsx
+++ b/src/components/DataTab.tsx
@@ -15,7 +15,7 @@ export default function DataTab() {
         ...INFLATION_RATES.map(d => d.year),
         ...Object.keys(CAPE_DATA).map(Number),
       ])
-    ).sort((a, b) => a - b);
+    ).sort((a, b) => b - a);
   }, []);
 
   const rows = useMemo(() => years.map(year => ({

--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -613,6 +613,9 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
               ⟳
             </button>
           </div>
+          <div className="text-xs text-slate-500">
+            Years: {Math.min(...years)}–{Math.max(...years)} (<a href="#data" className="text-blue-600 dark:text-blue-400 underline">Data</a>)
+          </div>
           <label className="block text-sm">Drawdown Strategy
             <select
               className="mt-1 w-full border rounded-xl p-2 bg-white dark:bg-slate-700 dark:border-slate-600"

--- a/src/components/Nasdaq100Tab.tsx
+++ b/src/components/Nasdaq100Tab.tsx
@@ -290,6 +290,9 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
                         ⟳
                     </button>
                 </div>
+                <div className="text-xs text-slate-500">
+                    Years: {Math.min(...years)}–{Math.max(...years)} (<a href="#data" className="text-blue-600 dark:text-blue-400 underline">Data</a>)
+                </div>
                 <div className="space-y-2 text-sm">
                     <label className="flex items-center gap-2">
                         <input

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -697,6 +697,9 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
               ⟳
             </button>
           </div>
+          <div className="text-xs text-slate-500">
+            Years: {Math.min(...years)}–{Math.max(...years)} (<a href="#data" className="text-blue-600 dark:text-blue-400 underline">Data</a>)
+          </div>
           <label className="block text-sm">Drawdown Order
             <select
               className="mt-1 w-full border rounded-xl p-2 bg-white dark:bg-slate-700 dark:border-slate-600"

--- a/src/components/S&P500Tab.tsx
+++ b/src/components/S&P500Tab.tsx
@@ -290,6 +290,9 @@ const SPTab: React.FC<SPTabProps> = ({
                         ⟳
                     </button>
                 </div>
+                <div className="text-xs text-slate-500">
+                    Years: {Math.min(...years)}–{Math.max(...years)} (<a href="#data" className="text-blue-600 dark:text-blue-400 underline">Data</a>)
+                </div>
                 <div className="space-y-2 text-sm">
                     <label className="flex items-center gap-2">
                         <input

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -40,7 +40,7 @@ const TabNavigation: React.FC<TabNavigationProps> = ({ activeTab, onTabChange })
         Drawdown Strategies
       </button>
       <button
-        className={`${baseTabClass} ${activeTab === 'data' ? activeClass : inactiveClass}`}
+        className={`${baseTabClass} ${activeTab === 'data' ? activeClass : inactiveClass} ml-auto bg-slate-200 dark:bg-slate-700 rounded-t-lg`}
         onClick={() => onTabChange('data')}
       >
         Data

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 interface TabNavigationProps {
-  activeTab: "sp500" | "nasdaq100" | "portfolio" | "drawdown";
-  onTabChange: (tab: "sp500" | "nasdaq100" | "portfolio" | "drawdown") => void;
+  activeTab: "sp500" | "nasdaq100" | "portfolio" | "drawdown" | "data";
+  onTabChange: (tab: "sp500" | "nasdaq100" | "portfolio" | "drawdown" | "data") => void;
 }
 
 const TabNavigation: React.FC<TabNavigationProps> = ({ activeTab, onTabChange }) => {
@@ -38,6 +38,12 @@ const TabNavigation: React.FC<TabNavigationProps> = ({ activeTab, onTabChange })
         onClick={() => onTabChange('drawdown')}
       >
         Drawdown Strategies
+      </button>
+      <button
+        className={`${baseTabClass} ${activeTab === 'data' ? activeClass : inactiveClass}`}
+        onClick={() => onTabChange('data')}
+      >
+        Data
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- add new Data tab displaying yearly returns, bond yields, inflation and CAPE
- wire hash-based navigation and add Data option in tab bar
- show available year range with link to Data tab in simulation settings and docs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad0df3c8c88324863d8c63ab0ca25d