### PR TITLE
Make random start sequence default

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,7 +88,7 @@ export default function App() {
     isFirstWithdrawLocked: false,
     inflationAdjust: true,
     inflationRate: 0.02,
-    mode: "actual-seq" as "actual-seq" | "actual-seq-random-start" | "random-shuffle" | "bootstrap",
+    mode: "actual-seq-random-start" as "actual-seq" | "actual-seq-random-start" | "random-shuffle" | "bootstrap",
     numRuns: 1000,
     seed: "" as number | "",
     startYear: years[0],

--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -710,6 +710,10 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
           </label>
           <div className="space-y-2 text-sm">
             <label className="flex items-center gap-2">
+              <input type="radio" name="mode" checked={mode === 'actual-seq-random-start'} onChange={() => onParamChange('mode', 'actual-seq-random-start')} />
+              Actual sequence (randomize start year)
+            </label>
+            <label className="flex items-center gap-2">
               <input
                 type="radio"
                 name="mode"
@@ -732,10 +736,6 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
                   onParamChange('startYear', clamped);
                 }}
               />
-            </label>
-            <label className="flex items-center gap-2">
-              <input type="radio" name="mode" checked={mode === 'actual-seq-random-start'} onChange={() => onParamChange('mode', 'actual-seq-random-start')} />
-              Actual sequence (randomize start year)
             </label>
             <label className="flex items-center gap-2">
               <input type="radio" name="mode" checked={mode === 'random-shuffle'} onChange={() => onParamChange('mode', 'random-shuffle')} />

--- a/src/components/Nasdaq100Tab.tsx
+++ b/src/components/Nasdaq100Tab.tsx
@@ -296,6 +296,10 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
                 </div>
                 <div className="space-y-2 text-sm">
                     <label className="flex items-center gap-2">
+                        <input type="radio" name="mode" checked={mode === 'actual-seq-random-start'} onChange={() => onParamChange('mode', 'actual-seq-random-start')} />
+                        Actual sequence (randomize start year)
+                    </label>
+                    <label className="flex items-center gap-2">
                         <input
                             type="radio"
                             name="mode"
@@ -318,10 +322,6 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
                                 onParamChange('startYear', clamped);
                             }}
                         />
-                    </label>
-                    <label className="flex items-center gap-2">
-                        <input type="radio" name="mode" checked={mode === 'actual-seq-random-start'} onChange={() => onParamChange('mode', 'actual-seq-random-start')} />
-                        Actual sequence (randomize start year)
                     </label>
                     <label className="flex items-center gap-2">
                         <input type="radio" name="mode" checked={mode === 'random-shuffle'} onChange={() => onParamChange('mode', 'random-shuffle')} />

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -719,6 +719,10 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
           </label>
           <div className="space-y-2 text-sm">
             <label className="flex items-center gap-2">
+              <input type="radio" name="mode" checked={mode === 'actual-seq-random-start'} onChange={() => onParamChange('mode', 'actual-seq-random-start')} />
+              Actual sequence (randomize start year)
+            </label>
+            <label className="flex items-center gap-2">
               <input
                 type="radio"
                 name="mode"
@@ -741,10 +745,6 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
                   onParamChange('startYear', clamped);
                 }}
               />
-            </label>
-            <label className="flex items-center gap-2">
-              <input type="radio" name="mode" checked={mode === 'actual-seq-random-start'} onChange={() => onParamChange('mode', 'actual-seq-random-start')} />
-              Actual sequence (randomize start year)
             </label>
             <label className="flex items-center gap-2">
               <input type="radio" name="mode" checked={mode === 'random-shuffle'} onChange={() => onParamChange('mode', 'random-shuffle')} />

--- a/src/components/S&P500Tab.tsx
+++ b/src/components/S&P500Tab.tsx
@@ -296,6 +296,10 @@ const SPTab: React.FC<SPTabProps> = ({
                 </div>
                 <div className="space-y-2 text-sm">
                     <label className="flex items-center gap-2">
+                        <input type="radio" name="mode" checked={mode === 'actual-seq-random-start'} onChange={() => onParamChange('mode', 'actual-seq-random-start')} />
+                        Actual sequence (randomize start year)
+                    </label>
+                    <label className="flex items-center gap-2">
                         <input
                             type="radio"
                             name="mode"
@@ -318,10 +322,6 @@ const SPTab: React.FC<SPTabProps> = ({
                                 onParamChange('startYear', clamped);
                             }}
                         />
-                    </label>
-                    <label className="flex items-center gap-2">
-                        <input type="radio" name="mode" checked={mode === 'actual-seq-random-start'} onChange={() => onParamChange('mode', 'actual-seq-random-start')} />
-                        Actual sequence (randomize start year)
                     </label>
                     <label className="flex items-center gap-2">
                         <input type="radio" name="mode" checked={mode === 'random-shuffle'} onChange={() => onParamChange('mode', 'random-shuffle')} />


### PR DESCRIPTION
## Summary
- Default withdrawal mode to "Actual sequence (randomize start year)"
- Place "Actual sequence (randomize start year)" first in mode selection lists across tabs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0aebd05808324aab75d4702190fe5