### PR TITLE
feat: make data editable and shareable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from "react";
 import { usePersistentState } from "./hooks/usePersistentState";
 import { useMemo } from "react";
-import { SP500_TOTAL_RETURNS, NASDAQ100_TOTAL_RETURNS, BITCOIN_TOTAL_RETURNS } from "./data/returns";
-import { TEN_YEAR_TREASURY_TOTAL_RETURNS } from "./data/bonds";
 import TabNavigation from "./components/TabNavigation";
 import SPTab from "./components/S&P500Tab";
 import Nasdaq100Tab from "./components/Nasdaq100Tab";
@@ -11,6 +9,7 @@ import DrawdownTab from "./components/DrawdownTab";
 import ProfileSelector, { type Profile } from "./components/ProfileSelector";
 import ThemeToggle from "./components/ThemeToggle";
 import DataTab from "./components/DataTab";
+import { useData } from "./data/DataContext";
 
 export interface ChartState {
   minimized: boolean;
@@ -42,6 +41,7 @@ export default function App() {
   const [activeTab, setActiveTab] = useState<
     "sp500" | "nasdaq100" | "portfolio" | "drawdown" | "data"
   >("sp500");
+  const { sp500, nasdaq100, bitcoin: bitcoinReturns, bonds: bondReturns } = useData();
 
   useEffect(() => {
     const handleHashChange = () => {
@@ -66,12 +66,14 @@ export default function App() {
   }, [activeTab]);
 
   const years = useMemo(() => {
-    const spyYears = new Set(SP500_TOTAL_RETURNS.map(d => d.year));
-    const qqqYears = new Set(NASDAQ100_TOTAL_RETURNS.map(d => d.year));
-    const btcYears = new Set(BITCOIN_TOTAL_RETURNS.map(d => d.year));
-    const bondYears = new Set(TEN_YEAR_TREASURY_TOTAL_RETURNS.map(d => d.year));
-    return Array.from(spyYears).filter(y => qqqYears.has(y) && btcYears.has(y) && bondYears.has(y)).sort((a, b) => a - b);
-  }, []);
+    const spyYears = new Set(sp500.map(d => d.year));
+    const qqqYears = new Set(nasdaq100.map(d => d.year));
+    const btcYears = new Set(bitcoinReturns.map(d => d.year));
+    const bondYears = new Set(bondReturns.map(d => d.year));
+    return Array.from(spyYears)
+      .filter(y => qqqYears.has(y) && btcYears.has(y) && bondYears.has(y))
+      .sort((a, b) => a - b);
+  }, [sp500, nasdaq100, bitcoinReturns, bondReturns]);
 
   const defaultParams = {
     startBalance: 1_000_000,

--- a/src/components/DataTab.tsx
+++ b/src/components/DataTab.tsx
@@ -1,41 +1,50 @@
 import { useMemo } from "react";
-import { SP500_TOTAL_RETURNS, NASDAQ100_TOTAL_RETURNS, BITCOIN_TOTAL_RETURNS } from "../data/returns";
-import { TEN_YEAR_TREASURY_TOTAL_RETURNS } from "../data/bonds";
-import { INFLATION_RATES } from "../data/inflation";
-import { CAPE_DATA } from "../data/cape";
+import { useData } from "../data/DataContext";
 
 export default function DataTab() {
+  const { sp500, nasdaq100, bitcoin, bonds, inflation, cape, updateSeries, reset } = useData();
   const years = useMemo(() => {
     return Array.from(
       new Set([
-        ...SP500_TOTAL_RETURNS.map(d => d.year),
-        ...NASDAQ100_TOTAL_RETURNS.map(d => d.year),
-        ...BITCOIN_TOTAL_RETURNS.map(d => d.year),
-        ...TEN_YEAR_TREASURY_TOTAL_RETURNS.map(d => d.year),
-        ...INFLATION_RATES.map(d => d.year),
-        ...Object.keys(CAPE_DATA).map(Number),
+        ...sp500.map(d => d.year),
+        ...nasdaq100.map(d => d.year),
+        ...bitcoin.map(d => d.year),
+        ...bonds.map(d => d.year),
+        ...inflation.map(d => d.year),
+        ...Object.keys(cape).map(Number),
       ])
     ).sort((a, b) => b - a);
-  }, []);
+  }, [sp500, nasdaq100, bitcoin, bonds, inflation, cape]);
 
-  const rows = useMemo(() => years.map(year => ({
-    year,
-    sp500: SP500_TOTAL_RETURNS.find(d => d.year === year)?.returnPct ?? null,
-    nasdaq100: NASDAQ100_TOTAL_RETURNS.find(d => d.year === year)?.returnPct ?? null,
-    bitcoin: BITCOIN_TOTAL_RETURNS.find(d => d.year === year)?.returnPct ?? null,
-    bonds: TEN_YEAR_TREASURY_TOTAL_RETURNS.find(d => d.year === year)?.returnPct ?? null,
-    inflation: INFLATION_RATES.find(d => d.year === year)?.inflationPct ?? null,
-    cape: CAPE_DATA[year] ?? null,
-  })), [years]);
+  const rows = useMemo(
+    () =>
+      years.map(year => ({
+        year,
+        sp500: sp500.find(d => d.year === year)?.returnPct ?? null,
+        nasdaq100: nasdaq100.find(d => d.year === year)?.returnPct ?? null,
+        bitcoin: bitcoin.find(d => d.year === year)?.returnPct ?? null,
+        bonds: bonds.find(d => d.year === year)?.returnPct ?? null,
+        inflation: inflation.find(d => d.year === year)?.inflationPct ?? null,
+        cape: cape[year] ?? null,
+      })),
+    [years, sp500, nasdaq100, bitcoin, bonds, inflation, cape]
+  );
 
-  const minYear = years[0];
-  const maxYear = years[years.length - 1];
+  const maxYear = years[0];
+  const minYear = years[years.length - 1];
 
   return (
     <div className="space-y-4">
       <p className="text-sm">
         Annual returns and metrics used for simulations. Data spans {minYear}–{maxYear}.
       </p>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded bg-slate-200 px-2 py-1 text-sm dark:bg-slate-700"
+      >
+        Reset to defaults
+      </button>
       <div className="overflow-x-auto">
         <table className="min-w-full text-sm">
           <thead className="sticky top-0 bg-white dark:bg-slate-800">
@@ -53,12 +62,111 @@ export default function DataTab() {
             {rows.map(r => (
               <tr key={r.year} className="border-b border-slate-200 dark:border-slate-700">
                 <td className="px-2 py-1 text-left">{r.year}</td>
-                <td className="px-2 py-1 text-right">{r.sp500 != null ? `${r.sp500.toFixed(2)}%` : "—"}</td>
-                <td className="px-2 py-1 text-right">{r.nasdaq100 != null ? `${r.nasdaq100.toFixed(2)}%` : "—"}</td>
-                <td className="px-2 py-1 text-right">{r.bitcoin != null ? `${r.bitcoin.toFixed(2)}%` : "—"}</td>
-                <td className="px-2 py-1 text-right">{r.bonds != null ? `${r.bonds.toFixed(2)}%` : "—"}</td>
-                <td className="px-2 py-1 text-right">{r.inflation != null ? `${r.inflation.toFixed(2)}%` : "—"}</td>
-                <td className="px-2 py-1 text-right">{r.cape != null ? r.cape.toFixed(2) : "—"}</td>
+                <td className="px-2 py-1 text-right">
+                  <div className="flex items-center justify-end">
+                    <input
+                      type="number"
+                      step="0.01"
+                      className="w-20 bg-transparent text-right"
+                      value={r.sp500 ?? ""}
+                      onChange={e =>
+                        updateSeries(
+                          "sp500",
+                          r.year,
+                          e.target.value === "" ? null : Number(e.target.value)
+                        )
+                      }
+                    />
+                    <span className="ml-1">%</span>
+                  </div>
+                </td>
+                <td className="px-2 py-1 text-right">
+                  <div className="flex items-center justify-end">
+                    <input
+                      type="number"
+                      step="0.01"
+                      className="w-20 bg-transparent text-right"
+                      value={r.nasdaq100 ?? ""}
+                      onChange={e =>
+                        updateSeries(
+                          "nasdaq100",
+                          r.year,
+                          e.target.value === "" ? null : Number(e.target.value)
+                        )
+                      }
+                    />
+                    <span className="ml-1">%</span>
+                  </div>
+                </td>
+                <td className="px-2 py-1 text-right">
+                  <div className="flex items-center justify-end">
+                    <input
+                      type="number"
+                      step="0.01"
+                      className="w-20 bg-transparent text-right"
+                      value={r.bitcoin ?? ""}
+                      onChange={e =>
+                        updateSeries(
+                          "bitcoin",
+                          r.year,
+                          e.target.value === "" ? null : Number(e.target.value)
+                        )
+                      }
+                    />
+                    <span className="ml-1">%</span>
+                  </div>
+                </td>
+                <td className="px-2 py-1 text-right">
+                  <div className="flex items-center justify-end">
+                    <input
+                      type="number"
+                      step="0.01"
+                      className="w-20 bg-transparent text-right"
+                      value={r.bonds ?? ""}
+                      onChange={e =>
+                        updateSeries(
+                          "bonds",
+                          r.year,
+                          e.target.value === "" ? null : Number(e.target.value)
+                        )
+                      }
+                    />
+                    <span className="ml-1">%</span>
+                  </div>
+                </td>
+                <td className="px-2 py-1 text-right">
+                  <div className="flex items-center justify-end">
+                    <input
+                      type="number"
+                      step="0.01"
+                      className="w-20 bg-transparent text-right"
+                      value={r.inflation ?? ""}
+                      onChange={e =>
+                        updateSeries(
+                          "inflation",
+                          r.year,
+                          e.target.value === "" ? null : Number(e.target.value)
+                        )
+                      }
+                    />
+                    <span className="ml-1">%</span>
+                  </div>
+                </td>
+                <td className="px-2 py-1 text-right">
+                  <input
+                    type="number"
+                    step="0.01"
+                    className="w-20 bg-transparent text-right"
+                    value={r.cape ?? ""}
+                    onChange={e =>
+                      updateSeries(
+                        "cape",
+                        r.year,
+                        e.target.value === "" ? null : Number(e.target.value)
+                      )
+                    }
+                  />
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -4,12 +4,10 @@ import { LayoutGroup, motion } from "framer-motion";
 import type { DrawdownStrategies } from "../App";
 import AllocationSlider from "./AllocationSlider";
 import CurrencyInput from "./CurrencyInput";
-import { SP500_TOTAL_RETURNS, NASDAQ100_TOTAL_RETURNS, BITCOIN_TOTAL_RETURNS } from "../data/returns";
-import { bitcoinReturnMultiplier } from "../lib/bitcoin";
 import Chart, { type ChartProps } from "./Chart";
 import type { ChartState } from "../App";
 import MinimizedChartsBar from "./MinimizedChartsBar";
-import { TEN_YEAR_TREASURY_TOTAL_RETURNS } from "../data/bonds";
+import { useData } from "../data/DataContext";
 import {
   pctToMult,
   bootstrapSample,
@@ -59,7 +57,6 @@ interface DrawdownTabProps {
   onReorderChartOrder?: (newOrder: string[]) => void;
 }
 
-import { CAPE_DATA } from "../data/cape";
 
 const DrawdownTab: React.FC<DrawdownTabProps> = ({
   drawdownWithdrawalStrategy,
@@ -111,32 +108,34 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
   });
 
   const currency = new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+  const { sp500, nasdaq100, bitcoin: btcReturns, bonds: bondReturns, cape } = useData();
 
   const years = useMemo(() => {
-    const spyYears = new Set(SP500_TOTAL_RETURNS.map(d => d.year));
-    const qqqYears = new Set(NASDAQ100_TOTAL_RETURNS.map(d => d.year));
-    const bondYears = new Set(TEN_YEAR_TREASURY_TOTAL_RETURNS.map(d => d.year));
-    const maxBitcoinYear = Math.max(...BITCOIN_TOTAL_RETURNS.map(d => d.year));
+    const spyYears = new Set(sp500.map(d => d.year));
+    const qqqYears = new Set(nasdaq100.map(d => d.year));
+    const bondYears = new Set(bondReturns.map(d => d.year));
+    const btcYears = new Set(btcReturns.map(d => d.year));
     return Array.from(spyYears)
-      .filter(y => qqqYears.has(y) && bondYears.has(y) && y <= maxBitcoinYear)
+      .filter(y => qqqYears.has(y) && bondYears.has(y) && btcYears.has(y))
       .sort((a, b) => a - b);
-  }, []);
+  }, [sp500, nasdaq100, bondReturns, btcReturns]);
 
   const returnsByYear = useMemo(() => {
     const map = new Map<number, { spy: number; qqq: number; bitcoin: number; bond: number }>();
-    const spyReturnsMap = new Map(SP500_TOTAL_RETURNS.map(d => [d.year, pctToMult(d.returnPct)]));
-    const qqqReturnsMap = new Map(NASDAQ100_TOTAL_RETURNS.map(d => [d.year, pctToMult(d.returnPct)]));
-    const bondReturnsMap = new Map(TEN_YEAR_TREASURY_TOTAL_RETURNS.map(d => [d.year, pctToMult(d.returnPct)]));
+    const spyReturnsMap = new Map(sp500.map(d => [d.year, pctToMult(d.returnPct)]));
+    const qqqReturnsMap = new Map(nasdaq100.map(d => [d.year, pctToMult(d.returnPct)]));
+    const bondReturnsMap = new Map(bondReturns.map(d => [d.year, pctToMult(d.returnPct)]));
+    const btcReturnsMap = new Map(btcReturns.map(d => [d.year, pctToMult(d.returnPct)]));
     for (const year of years) {
       map.set(year, {
         spy: spyReturnsMap.get(year)!,
         qqq: qqqReturnsMap.get(year)!,
-        bitcoin: bitcoin > 0 ? bitcoinReturnMultiplier(year) : 1.0,
+        bitcoin: bitcoin > 0 ? btcReturnsMap.get(year)! : 1.0,
         bond: bondReturnsMap.get(year)!,
       });
     }
     return map;
-  }, [years, bitcoin]);
+  }, [years, bitcoin, sp500, nasdaq100, btcReturns, bondReturns]);
 
   const sims = useMemo(() => {
     const runs: PortfolioRunResult[] = [];
@@ -155,7 +154,24 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
       } else if (strategy === "floorAndCeiling") {
         runs.push(simulateFloorAndCeiling(spyReturns, qqqReturns, bitcoinReturns, bondReturns, cash, spy, qqq, bitcoin, bonds, horizon, initialW, inflationRate, inflationAdjust, floorAndCeilingParams.floor, floorAndCeilingParams.ceiling));
       } else if (strategy === "capeBased") {
-        runs.push(simulateCapeBased(spyReturns, qqqReturns, bitcoinReturns, bondReturns, cash, spy, qqq, bitcoin, bonds, horizon, capeBasedParams.basePercentage, capeBasedParams.capeFraction, CAPE_DATA, yearSample));
+        runs.push(
+          simulateCapeBased(
+            spyReturns,
+            qqqReturns,
+            bitcoinReturns,
+            bondReturns,
+            cash,
+            spy,
+            qqq,
+            bitcoin,
+            bonds,
+            horizon,
+            capeBasedParams.basePercentage,
+            capeBasedParams.capeFraction,
+            cape,
+            yearSample
+          )
+        );
       } else if (strategy === "fixedPercentage") {
         runs.push(simulateFixedPercentage(spyReturns, qqqReturns, bitcoinReturns, bondReturns, cash, spy, qqq, bitcoin, bonds, horizon, fixedPercentageParams.withdrawalRate));
       } else if (strategy === "principalProtectionRule") {
@@ -187,7 +203,24 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         } else if (strategy === "floorAndCeiling") {
           runs.push(simulateFloorAndCeiling(spyReturns, qqqReturns, bitcoinReturns, bondReturns, cash, spy, qqq, bitcoin, bonds, horizon, initialW, inflationRate, inflationAdjust, floorAndCeilingParams.floor, floorAndCeilingParams.ceiling));
         } else if (strategy === "capeBased") {
-          runs.push(simulateCapeBased(spyReturns, qqqReturns, bitcoinReturns, bondReturns, cash, spy, qqq, bitcoin, bonds, horizon, capeBasedParams.basePercentage, capeBasedParams.capeFraction, CAPE_DATA, yearSample));
+          runs.push(
+            simulateCapeBased(
+              spyReturns,
+              qqqReturns,
+              bitcoinReturns,
+              bondReturns,
+              cash,
+              spy,
+              qqq,
+              bitcoin,
+              bonds,
+              horizon,
+              capeBasedParams.basePercentage,
+              capeBasedParams.capeFraction,
+              cape,
+              yearSample
+            )
+          );
         } else if (strategy === "fixedPercentage") {
           runs.push(simulateFixedPercentage(spyReturns, qqqReturns, bitcoinReturns, bondReturns, cash, spy, qqq, bitcoin, bonds, horizon, fixedPercentageParams.withdrawalRate));
         } else if (strategy === "principalProtectionRule") {
@@ -201,7 +234,30 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
     }
     return runs;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cash, spy, qqq, bitcoin, bonds, horizon, initialWithdrawalAmount, inflationRate, inflationAdjust, mode, numRuns, startYear, returnsByYear, startBalance, years, refreshCounter, strategy, guytonKlingerParams, floorAndCeilingParams, capeBasedParams, fixedPercentageParams]);
+  }, [
+    cash,
+    spy,
+    qqq,
+    bitcoin,
+    bonds,
+    horizon,
+    initialWithdrawalAmount,
+    inflationRate,
+    inflationAdjust,
+    mode,
+    numRuns,
+    startYear,
+    returnsByYear,
+    startBalance,
+    years,
+    refreshCounter,
+    strategy,
+    guytonKlingerParams,
+    floorAndCeilingParams,
+    capeBasedParams,
+    fixedPercentageParams,
+    cape,
+  ]);
 
 
   const stats = useMemo(() => {

--- a/src/components/Nasdaq100Tab.tsx
+++ b/src/components/Nasdaq100Tab.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, Area, AreaChart, CartesianGrid } from "recharts";
 import { LayoutGroup, motion } from "framer-motion";
-import { NASDAQ100_TOTAL_RETURNS } from "../data/returns";
+import { useData } from "../data/DataContext";
 import { pctToMult, bootstrapSample, shuffle, percentile, calculateDrawdownStats } from "../lib/simulation";
 import type { RunResult } from "../lib/simulation";
 import CurrencyInput from "./CurrencyInput";
@@ -91,14 +91,15 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
   chartOrder,
   onReorderChartOrder,
 }) => {
-  const years = useMemo(() => NASDAQ100_TOTAL_RETURNS.map(d => d.year).sort((a, b) => a - b), []);
-  const availableMultipliers = useMemo(() => NASDAQ100_TOTAL_RETURNS.map(d => pctToMult(d.returnPct)), []);
+  const { nasdaq100 } = useData();
+  const years = useMemo(() => nasdaq100.map(d => d.year).sort((a, b) => a - b), [nasdaq100]);
+  const availableMultipliers = useMemo(() => nasdaq100.map(d => pctToMult(d.returnPct)), [nasdaq100]);
 
   const sims = useMemo(() => {
     const initW = withdrawRate / 100;
     const runs: RunResult[] = [];
     const multipliers = availableMultipliers; // unsorted
-    const sortedReturns = NASDAQ100_TOTAL_RETURNS.slice().sort((a, b) => a.year - b.year);
+    const sortedReturns = nasdaq100.slice().sort((a, b) => a.year - b.year);
     const multipliersChrono = sortedReturns.map(d => pctToMult(d.returnPct));
     const yearsSorted = sortedReturns.map(d => d.year);
 

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -2,9 +2,7 @@ import React, { useMemo } from "react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, Area, AreaChart, CartesianGrid } from "recharts";
 import { LayoutGroup, motion } from "framer-motion";
 import type { DrawdownStrategy } from "../App";
-import { SP500_TOTAL_RETURNS, NASDAQ100_TOTAL_RETURNS, BITCOIN_TOTAL_RETURNS } from "../data/returns";
-import { bitcoinReturnMultiplier } from "../lib/bitcoin";
-import { TEN_YEAR_TREASURY_TOTAL_RETURNS } from "../data/bonds";
+import { useData } from "../data/DataContext";
 import { pctToMult, bootstrapSample, shuffle, percentile, calculateDrawdownStats } from "../lib/simulation";
 import AllocationSlider from "./AllocationSlider";
 import CurrencyInput from "./CurrencyInput";
@@ -238,32 +236,34 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
   const currency = new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 });
   const [draggingId, setDraggingId] = React.useState<string | null>(null);
   const [overId, setOverId] = React.useState<string | null>(null);
+  const { sp500, nasdaq100, bitcoin: btcReturns, bonds: bondReturns } = useData();
 
   const years = useMemo(() => {
-    const spyYears = new Set(SP500_TOTAL_RETURNS.map(d => d.year));
-    const qqqYears = new Set(NASDAQ100_TOTAL_RETURNS.map(d => d.year));
-    const bondYears = new Set(TEN_YEAR_TREASURY_TOTAL_RETURNS.map(d => d.year));
-    const maxBitcoinYear = Math.max(...BITCOIN_TOTAL_RETURNS.map(d => d.year));
+    const spyYears = new Set(sp500.map(d => d.year));
+    const qqqYears = new Set(nasdaq100.map(d => d.year));
+    const bondYears = new Set(bondReturns.map(d => d.year));
+    const btcYears = new Set(btcReturns.map(d => d.year));
     return Array.from(spyYears)
-      .filter(y => qqqYears.has(y) && bondYears.has(y) && y <= maxBitcoinYear)
+      .filter(y => qqqYears.has(y) && bondYears.has(y) && btcYears.has(y))
       .sort((a, b) => a - b);
-  }, []);
+  }, [sp500, nasdaq100, bondReturns, btcReturns]);
 
   const returnsByYear = useMemo(() => {
     const map = new Map<number, { spy: number; qqq: number; bitcoin: number; bonds: number }>();
-    const spyReturnsMap = new Map(SP500_TOTAL_RETURNS.map(d => [d.year, pctToMult(d.returnPct)]));
-    const qqqReturnsMap = new Map(NASDAQ100_TOTAL_RETURNS.map(d => [d.year, pctToMult(d.returnPct)]));
-    const bondReturnsMap = new Map(TEN_YEAR_TREASURY_TOTAL_RETURNS.map(d => [d.year, pctToMult(d.returnPct)]));
+    const spyReturnsMap = new Map(sp500.map(d => [d.year, pctToMult(d.returnPct)]));
+    const qqqReturnsMap = new Map(nasdaq100.map(d => [d.year, pctToMult(d.returnPct)]));
+    const bondReturnsMap = new Map(bondReturns.map(d => [d.year, pctToMult(d.returnPct)]));
+    const btcReturnsMap = new Map(btcReturns.map(d => [d.year, pctToMult(d.returnPct)]));
     for (const year of years) {
       map.set(year, {
         spy: spyReturnsMap.get(year)!,
         qqq: qqqReturnsMap.get(year)!,
-        bitcoin: bitcoin > 0 ? bitcoinReturnMultiplier(year) : 1.0,
+        bitcoin: bitcoin > 0 ? btcReturnsMap.get(year)! : 1.0,
         bonds: bondReturnsMap.get(year)!,
       });
     }
     return map;
-  }, [years, bitcoin]);
+  }, [years, bitcoin, sp500, nasdaq100, btcReturns, bondReturns]);
 
   const sims = useMemo(() => {
     const runs: PortfolioRunResult[] = [];

--- a/src/components/S&P500Tab.tsx
+++ b/src/components/S&P500Tab.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, Area, AreaChart, CartesianGrid } from "recharts";
 import { LayoutGroup, motion } from "framer-motion";
-import { SP500_TOTAL_RETURNS } from "../data/returns";
+import { useData } from "../data/DataContext";
 import { pctToMult, bootstrapSample, shuffle, percentile, calculateDrawdownStats } from "../lib/simulation";
 import type { RunResult } from "../lib/simulation";
 import CurrencyInput from "./CurrencyInput";
@@ -91,14 +91,15 @@ const SPTab: React.FC<SPTabProps> = ({
   chartOrder,
   onReorderChartOrder,
 }) => {
-  const years = useMemo(() => SP500_TOTAL_RETURNS.map(d => d.year).sort((a, b) => a - b), []);
-  const availableMultipliers = useMemo(() => SP500_TOTAL_RETURNS.map(d => pctToMult(d.returnPct)), []);
+  const { sp500 } = useData();
+  const years = useMemo(() => sp500.map(d => d.year).sort((a, b) => a - b), [sp500]);
+  const availableMultipliers = useMemo(() => sp500.map(d => pctToMult(d.returnPct)), [sp500]);
 
   const sims = useMemo(() => {
     const initW = withdrawRate / 100;
     const runs: RunResult[] = [];
     const multipliers = availableMultipliers; // unsorted
-    const sortedReturns = SP500_TOTAL_RETURNS.slice().sort((a, b) => a.year - b.year);
+    const sortedReturns = sp500.slice().sort((a, b) => a.year - b.year);
     const multipliersChrono = sortedReturns.map(d => pctToMult(d.returnPct));
     const yearsSorted = sortedReturns.map(d => d.year);
 

--- a/src/data/DataContext.tsx
+++ b/src/data/DataContext.tsx
@@ -1,0 +1,96 @@
+import { createContext, useContext, useState, type ReactNode } from "react";
+import { SP500_TOTAL_RETURNS, NASDAQ100_TOTAL_RETURNS, BITCOIN_TOTAL_RETURNS } from "./returns";
+import { TEN_YEAR_TREASURY_TOTAL_RETURNS } from "./bonds";
+import { INFLATION_RATES } from "./inflation";
+import { CAPE_DATA } from "./cape";
+
+interface DataState {
+  sp500: { year: number; returnPct: number }[];
+  nasdaq100: { year: number; returnPct: number }[];
+  bitcoin: { year: number; returnPct: number }[];
+  bonds: { year: number; returnPct: number }[];
+  inflation: { year: number; inflationPct: number }[];
+  cape: { [year: number]: number };
+}
+
+interface DataContextValue extends DataState {
+  updateSeries: (series: keyof DataState, year: number, value: number | null) => void;
+  reset: () => void;
+}
+
+const DataContext = createContext<DataContextValue | undefined>(undefined);
+
+const defaultData: DataState = {
+  sp500: SP500_TOTAL_RETURNS.map(d => ({ ...d })),
+  nasdaq100: NASDAQ100_TOTAL_RETURNS.map(d => ({ ...d })),
+  bitcoin: BITCOIN_TOTAL_RETURNS.map(d => ({ ...d })),
+  bonds: TEN_YEAR_TREASURY_TOTAL_RETURNS.map(d => ({ ...d })),
+  inflation: INFLATION_RATES.map(d => ({ ...d })),
+  cape: { ...CAPE_DATA },
+};
+
+export function DataProvider({ children }: { children: ReactNode }) {
+  const [sp500, setSp500] = useState(defaultData.sp500);
+  const [nasdaq100, setNasdaq100] = useState(defaultData.nasdaq100);
+  const [bitcoin, setBitcoin] = useState(defaultData.bitcoin);
+  const [bonds, setBonds] = useState(defaultData.bonds);
+  const [inflation, setInflation] = useState(defaultData.inflation);
+  const [cape, setCape] = useState(defaultData.cape);
+
+  const updateArray = <T extends { year: number }>(
+    arr: T[],
+    year: number,
+    value: number | null,
+    key: keyof T
+  ): T[] => {
+    const idx = arr.findIndex(d => d.year === year);
+    if (idx === -1) return arr;
+    const next = arr.slice();
+    next[idx] = { ...next[idx], [key]: value } as T;
+    return next;
+  };
+
+  const updateSeries = (
+    series: keyof DataState,
+    year: number,
+    value: number | null
+  ) => {
+    if (series === "sp500") setSp500(p => updateArray(p, year, value, "returnPct"));
+    else if (series === "nasdaq100") setNasdaq100(p => updateArray(p, year, value, "returnPct"));
+    else if (series === "bitcoin") setBitcoin(p => updateArray(p, year, value, "returnPct"));
+    else if (series === "bonds") setBonds(p => updateArray(p, year, value, "returnPct"));
+    else if (series === "inflation") setInflation(p => updateArray(p, year, value, "inflationPct"));
+    else if (series === "cape")
+      setCape(p => {
+        const next = { ...p };
+        if (value == null || Number.isNaN(value)) delete next[year];
+        else next[year] = value;
+        return next;
+      });
+  };
+
+  const reset = () => {
+    setSp500(defaultData.sp500.map(d => ({ ...d })));
+    setNasdaq100(defaultData.nasdaq100.map(d => ({ ...d })));
+    setBitcoin(defaultData.bitcoin.map(d => ({ ...d })));
+    setBonds(defaultData.bonds.map(d => ({ ...d })));
+    setInflation(defaultData.inflation.map(d => ({ ...d })));
+    setCape({ ...defaultData.cape });
+  };
+
+  return (
+    <DataContext.Provider
+      value={{ sp500, nasdaq100, bitcoin, bonds, inflation, cape, updateSeries, reset }}
+    >
+      {children}
+    </DataContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useData() {
+  const ctx = useContext(DataContext);
+  if (!ctx) throw new Error("useData must be used within DataProvider");
+  return ctx;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css' // <-- important
+import { DataProvider } from './data/DataContext'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <DataProvider>
+      <App />
+    </DataProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary
- centralize simulation data in a DataContext to allow live editing and reset
- expose editable table in Data tab and add reset to defaults
- update simulation tabs to consume shared data

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5f958ea7883249905c743de9f296f