### PR TITLE
fix: extend history when bitcoin unused

### DIFF
--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -23,6 +23,7 @@ import {
   simulateFixedPercentage,
   simulateCapeBased,
 } from "../lib/simulation";
+import { bitcoinReturnMultiplier } from "../lib/bitcoin";
 
 // ... (imports)
 
@@ -114,11 +115,10 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
     const spyYears = new Set(sp500.map(d => d.year));
     const qqqYears = new Set(nasdaq100.map(d => d.year));
     const bondYears = new Set(bondReturns.map(d => d.year));
-    const btcYears = new Set(btcReturns.map(d => d.year));
     return Array.from(spyYears)
-      .filter(y => qqqYears.has(y) && bondYears.has(y) && btcYears.has(y))
+      .filter(y => qqqYears.has(y) && bondYears.has(y))
       .sort((a, b) => a - b);
-  }, [sp500, nasdaq100, bondReturns, btcReturns]);
+  }, [sp500, nasdaq100, bondReturns]);
 
   const returnsByYear = useMemo(() => {
     const map = new Map<number, { spy: number; qqq: number; bitcoin: number; bond: number }>();
@@ -130,7 +130,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
       map.set(year, {
         spy: spyReturnsMap.get(year)!,
         qqq: qqqReturnsMap.get(year)!,
-        bitcoin: bitcoin > 0 ? btcReturnsMap.get(year)! : 1.0,
+        bitcoin: bitcoin > 0 ? (btcReturnsMap.get(year) ?? bitcoinReturnMultiplier(year)) : 1.0,
         bond: bondReturnsMap.get(year)!,
       });
     }

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -4,6 +4,7 @@ import { LayoutGroup, motion } from "framer-motion";
 import type { DrawdownStrategy } from "../App";
 import { useData } from "../data/DataContext";
 import { pctToMult, bootstrapSample, shuffle, percentile, calculateDrawdownStats } from "../lib/simulation";
+import { bitcoinReturnMultiplier } from "../lib/bitcoin";
 import AllocationSlider from "./AllocationSlider";
 import CurrencyInput from "./CurrencyInput";
 import Chart, { type ChartProps } from "./Chart";
@@ -242,11 +243,10 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
     const spyYears = new Set(sp500.map(d => d.year));
     const qqqYears = new Set(nasdaq100.map(d => d.year));
     const bondYears = new Set(bondReturns.map(d => d.year));
-    const btcYears = new Set(btcReturns.map(d => d.year));
     return Array.from(spyYears)
-      .filter(y => qqqYears.has(y) && bondYears.has(y) && btcYears.has(y))
+      .filter(y => qqqYears.has(y) && bondYears.has(y))
       .sort((a, b) => a - b);
-  }, [sp500, nasdaq100, bondReturns, btcReturns]);
+  }, [sp500, nasdaq100, bondReturns]);
 
   const returnsByYear = useMemo(() => {
     const map = new Map<number, { spy: number; qqq: number; bitcoin: number; bonds: number }>();
@@ -258,7 +258,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
       map.set(year, {
         spy: spyReturnsMap.get(year)!,
         qqq: qqqReturnsMap.get(year)!,
-        bitcoin: bitcoin > 0 ? btcReturnsMap.get(year)! : 1.0,
+        bitcoin: bitcoin > 0 ? (btcReturnsMap.get(year) ?? bitcoinReturnMultiplier(year)) : 1.0,
         bonds: bondReturnsMap.get(year)!,
       });
     }


### PR DESCRIPTION
## Summary
- allow drawdown and portfolio simulations to use full data history when bitcoin allocation is zero
- synthesize bitcoin returns for missing years via `bitcoinReturnMultiplier`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b72a56f74c83248b1073b94974999c