### PR TITLE
feat: debounce simulation updates

### DIFF
--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useEffect, useRef } from "react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, Area, AreaChart, CartesianGrid, ReferenceDot } from "recharts";
 import { LayoutGroup, motion } from "framer-motion";
 import type { DrawdownStrategies } from "../App";
@@ -138,6 +138,17 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
     return map;
   }, [years, bitcoin, sp500, nasdaq100, btcReturns, bondReturns]);
 
+  const firstRender = useRef(true);
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    const id = setTimeout(onRefresh, 1000);
+    return () => clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [drawdownWithdrawalStrategy, startBalance, cash, spy, qqq, bitcoin, bonds, horizon, withdrawRate, initialWithdrawalAmount, inflationAdjust, inflationRate, mode, numRuns, seed, startYear, guytonKlingerParams, floorAndCeilingParams, capeBasedParams, fixedPercentageParams]);
+
   const sims = useMemo(() => {
     const runs: PortfolioRunResult[] = [];
     const initialW = initialWithdrawalAmount / startBalance;
@@ -235,30 +246,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
     }
     return runs;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    cash,
-    spy,
-    qqq,
-    bitcoin,
-    bonds,
-    horizon,
-    initialWithdrawalAmount,
-    inflationRate,
-    inflationAdjust,
-    mode,
-    numRuns,
-    startYear,
-    returnsByYear,
-    startBalance,
-    years,
-    refreshCounter,
-    strategy,
-    guytonKlingerParams,
-    floorAndCeilingParams,
-    capeBasedParams,
-    fixedPercentageParams,
-    cape,
-  ]);
+  }, [refreshCounter]);
 
 
   const stats = useMemo(() => {

--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -109,7 +109,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
     withdrawalRate: 0.04,
   });
 
-  const currency = new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+  const currency = useMemo(() => new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 }), []);
   const { sp500, nasdaq100, bitcoin: btcReturns, bonds: bondReturns, cape } = useData();
 
   const years = useMemo(() => {
@@ -144,7 +144,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
       firstRender.current = false;
       return;
     }
-    const id = setTimeout(onRefresh, 1000);
+    const id = setTimeout(onRefresh, 100);
     return () => clearTimeout(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [drawdownWithdrawalStrategy, startBalance, cash, spy, qqq, bitcoin, bonds, horizon, withdrawRate, initialWithdrawalAmount, inflationAdjust, inflationRate, mode, numRuns, seed, startYear, guytonKlingerParams, floorAndCeilingParams, capeBasedParams, fixedPercentageParams]);
@@ -300,7 +300,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
 
   const sampleRun = sims[0];
 
-  const charts: Record<string, React.ReactElement<ChartProps>> = {
+  const charts: Record<string, React.ReactElement<ChartProps>> = useMemo(() => ({
     'drawdown-trajectory': (
       <Chart
         chartId="drawdown-trajectory"
@@ -308,6 +308,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('drawdown-trajectory')}
         onToggleSize={() => toggleSize('drawdown-trajectory')}
+        onDragStart={() => setDraggingId('drawdown-trajectory')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['drawdown-trajectory']?.size ?? 'full'}
         minimizable={true}
       >
@@ -341,6 +343,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('drawdown-median-asset-allocation')}
         onToggleSize={() => toggleSize('drawdown-median-asset-allocation')}
+        onDragStart={() => setDraggingId('drawdown-median-asset-allocation')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['drawdown-median-asset-allocation']?.size ?? 'half'}
         minimizable={true}
       >
@@ -381,6 +385,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('drawdown-median-trajectory')}
         onToggleSize={() => toggleSize('drawdown-median-trajectory')}
+        onDragStart={() => setDraggingId('drawdown-median-trajectory')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['drawdown-median-trajectory']?.size ?? 'half'}
         minimizable={true}
       >
@@ -421,6 +427,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('drawdown-asset-allocation')}
         onToggleSize={() => toggleSize('drawdown-asset-allocation')}
+        onDragStart={() => setDraggingId('drawdown-asset-allocation')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['drawdown-asset-allocation']?.size ?? 'half'}
         minimizable={true}
       >
@@ -461,6 +469,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('drawdown-sample')}
         onToggleSize={() => toggleSize('drawdown-sample')}
+        onDragStart={() => setDraggingId('drawdown-sample')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['drawdown-sample']?.size ?? 'half'}
         minimizable={true}
       >
@@ -517,6 +527,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
           onRefresh={onRefresh}
           onMinimize={() => toggleMinimize(`drawdown-sample-${i}-asset-allocation`)}
           onToggleSize={() => toggleSize(`drawdown-sample-${i}-asset-allocation`)}
+          onDragStart={() => setDraggingId(`drawdown-sample-${i}-asset-allocation`)}
+          onDragEnd={() => { setDraggingId(null); setOverId(null); }}
           size={chartStates[`drawdown-sample-${i}-asset-allocation`]?.size ?? 'half'}
           minimizable={true}
         >
@@ -555,6 +567,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
           onRefresh={onRefresh}
           onMinimize={() => toggleMinimize(`drawdown-sample-${i}-trajectory`)}
           onToggleSize={() => toggleSize(`drawdown-sample-${i}-trajectory`)}
+          onDragStart={() => setDraggingId(`drawdown-sample-${i}-trajectory`)}
+          onDragEnd={() => { setDraggingId(null); setOverId(null); }}
           size={chartStates[`drawdown-sample-${i}-trajectory`]?.size ?? 'half'}
           minimizable={true}
         >
@@ -588,7 +602,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
       );
       return acc;
     }, {} as Record<string, React.ReactElement<ChartProps>>),
-  };
+  }), [chartStates, onRefresh, toggleMinimize, toggleSize, stats, sims, currency, sampleRun]);
 
   return (
     <div className="space-y-6">
@@ -893,13 +907,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
                     <span className="px-2 py-1 rounded-md bg-white/90 dark:bg-slate-900/90 text-slate-900 dark:text-slate-100 shadow">Drop Here</span>
                   </div>
                 )}
-                {React.cloneElement<ChartProps>(
-                  charts[chartId],
-                  {
-                    onDragStart: () => setDraggingId(chartId),
-                    onDragEnd: () => { setDraggingId(null); setOverId(null); },
-                  }
-                )}
+                {charts[chartId]}
               </motion.div>
             )
           ))}

--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -246,7 +246,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
     }
     return runs;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshCounter]);
+  }, [refreshCounter, returnsByYear]);
 
 
   const stats = useMemo(() => {

--- a/src/components/MinimizedChartsBar.tsx
+++ b/src/components/MinimizedChartsBar.tsx
@@ -31,4 +31,4 @@ const MinimizedChartsBar: React.FC<MinimizedChartsBarProps> = ({ chartStates, on
   );
 };
 
-export default MinimizedChartsBar;
+export default React.memo(MinimizedChartsBar);

--- a/src/components/Nasdaq100Tab.tsx
+++ b/src/components/Nasdaq100Tab.tsx
@@ -102,7 +102,7 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
       firstRender.current = false;
       return;
     }
-    const id = setTimeout(onRefresh, 1000);
+    const id = setTimeout(onRefresh, 100);
     return () => clearTimeout(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [startBalance, horizon, withdrawRate, inflationRate, inflationAdjust, mode, numRuns, seed, startYear]);
@@ -181,9 +181,9 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
   }, [sims, horizon]);
 
   const sampleRun = sims[0];
-  const currency = new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+  const currency = useMemo(() => new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 }), []);
 
-  const charts: Record<string, React.ReactElement<ChartProps>> = {
+  const charts: Record<string, React.ReactElement<ChartProps>> = useMemo(() => ({
     'nasdaq100-trajectory': (
       <Chart
         chartId="nasdaq100-trajectory"
@@ -191,6 +191,8 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('nasdaq100-trajectory')}
         onToggleSize={() => toggleSize('nasdaq100-trajectory')}
+        onDragStart={() => setDraggingId('nasdaq100-trajectory')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['nasdaq100-trajectory']?.size ?? 'half'}
         minimizable={true}
       >
@@ -224,6 +226,8 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('nasdaq100-median-trajectory')}
         onToggleSize={() => toggleSize('nasdaq100-median-trajectory')}
+        onDragStart={() => setDraggingId('nasdaq100-median-trajectory')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['nasdaq100-median-trajectory']?.size ?? 'half'}
         minimizable={true}
       >
@@ -264,6 +268,8 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('nasdaq100-sample')}
         onToggleSize={() => toggleSize('nasdaq100-sample')}
+        onDragStart={() => setDraggingId('nasdaq100-sample')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['nasdaq100-sample']?.size ?? 'half'}
         minimizable={true}
       >
@@ -307,6 +313,8 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
           onRefresh={onRefresh}
           onMinimize={() => toggleMinimize(`nasdaq100-sample-${i}-trajectory`)}
           onToggleSize={() => toggleSize(`nasdaq100-sample-${i}-trajectory`)}
+          onDragStart={() => setDraggingId(`nasdaq100-sample-${i}-trajectory`)}
+          onDragEnd={() => { setDraggingId(null); setOverId(null); }}
           size={chartStates[`nasdaq100-sample-${i}-trajectory`]?.size ?? 'half'}
           minimizable={true}
         >
@@ -340,7 +348,7 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
       );
       return acc;
     }, {} as Record<string, React.ReactElement<ChartProps>>),
-  };
+  }), [chartStates, onRefresh, toggleMinimize, toggleSize, stats, sims, currency, sampleRun]);
 
   const [draggingId, setDraggingId] = React.useState<string | null>(null);
   const [overId, setOverId] = React.useState<string | null>(null);
@@ -555,13 +563,7 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
                     <span className="px-2 py-1 rounded-md bg-white/90 dark:bg-slate-900/90 text-slate-900 dark:text-slate-100 shadow">Drop Here</span>
                   </div>
                 )}
-                {React.cloneElement<ChartProps>(
-                  charts[chartId],
-                  {
-                    onDragStart: () => setDraggingId(chartId),
-                    onDragEnd: () => { setDraggingId(null); setOverId(null); },
-                  }
-                )}
+                {charts[chartId]}
               </motion.div>
             )
           ))}

--- a/src/components/Nasdaq100Tab.tsx
+++ b/src/components/Nasdaq100Tab.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useEffect, useRef } from "react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, Area, AreaChart, CartesianGrid } from "recharts";
 import { LayoutGroup, motion } from "framer-motion";
 import { useData } from "../data/DataContext";
@@ -96,6 +96,17 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
   const years = useMemo(() => nasdaq100.map(d => d.year).sort((a, b) => a - b), [nasdaq100]);
   const availableMultipliers = useMemo(() => nasdaq100.map(d => pctToMult(d.returnPct)), [nasdaq100]);
 
+  const firstRender = useRef(true);
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    const id = setTimeout(onRefresh, 1000);
+    return () => clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [startBalance, horizon, withdrawRate, inflationRate, inflationAdjust, mode, numRuns, seed, startYear]);
+
   const sims = useMemo(() => {
     const initW = withdrawRate / 100;
     const runs: RunResult[] = [];
@@ -127,7 +138,7 @@ const Nasdaq100Tab: React.FC<NasdaqTabProps> = ({
     }
     return runs;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, numRuns, availableMultipliers, horizon, startBalance, withdrawRate, inflationRate, inflationAdjust, startYear, refreshCounter]);
+  }, [availableMultipliers, nasdaq100, refreshCounter]);
 
   const stats = useMemo(() => {
     if (sims.length === 0) return null;

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -312,7 +312,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
     }
     return runs;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshCounter]);
+  }, [refreshCounter, returnsByYear]);
 
 
   const stats = useMemo(() => {

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -235,7 +235,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
   chartOrder,
   onReorderChartOrder,
 }) => {
-  const currency = new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+  const currency = useMemo(() => new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 }), []);
   const [draggingId, setDraggingId] = React.useState<string | null>(null);
   const [overId, setOverId] = React.useState<string | null>(null);
   const { sp500, nasdaq100, bitcoin: btcReturns, bonds: bondReturns } = useData();
@@ -272,7 +272,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
       firstRender.current = false;
       return;
     }
-    const id = setTimeout(onRefresh, 1000);
+    const id = setTimeout(onRefresh, 100);
     return () => clearTimeout(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [startBalance, cash, spy, qqq, bitcoin, bonds, drawdownStrategy, horizon, withdrawRate, initialWithdrawalAmount, inflationAdjust, inflationRate, mode, numRuns, seed, startYear]);
@@ -364,7 +364,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
 
   const sampleRun = sims[0];
 
-  const charts: Record<string, React.ReactElement<ChartProps>> = {
+  const charts: Record<string, React.ReactElement<ChartProps>> = useMemo(() => ({
     'portfolio-trajectory': (
       <Chart
         chartId="portfolio-trajectory"
@@ -372,6 +372,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('portfolio-trajectory')}
         onToggleSize={() => toggleSize('portfolio-trajectory')}
+        onDragStart={() => setDraggingId('portfolio-trajectory')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['portfolio-trajectory']?.size ?? 'full'}
         minimizable={true}
       >
@@ -402,6 +404,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('portfolio-median-asset-allocation')}
         onToggleSize={() => toggleSize('portfolio-median-asset-allocation')}
+        onDragStart={() => setDraggingId('portfolio-median-asset-allocation')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['portfolio-median-asset-allocation']?.size ?? 'half'}
         minimizable={true}
       >
@@ -442,6 +446,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('portfolio-median-trajectory')}
         onToggleSize={() => toggleSize('portfolio-median-trajectory')}
+        onDragStart={() => setDraggingId('portfolio-median-trajectory')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['portfolio-median-trajectory']?.size ?? 'half'}
         minimizable={true}
       >
@@ -482,6 +488,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('portfolio-asset-allocation')}
         onToggleSize={() => toggleSize('portfolio-asset-allocation')}
+        onDragStart={() => setDraggingId('portfolio-asset-allocation')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['portfolio-asset-allocation']?.size ?? 'half'}
         minimizable={true}
       >
@@ -522,6 +530,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('portfolio-sample')}
         onToggleSize={() => toggleSize('portfolio-sample')}
+        onDragStart={() => setDraggingId('portfolio-sample')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['portfolio-sample']?.size ?? 'half'}
         minimizable={true}
       >
@@ -565,6 +575,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
           onRefresh={onRefresh}
           onMinimize={() => toggleMinimize(`portfolio-sample-${i}-asset-allocation`)}
           onToggleSize={() => toggleSize(`portfolio-sample-${i}-asset-allocation`)}
+          onDragStart={() => setDraggingId(`portfolio-sample-${i}-asset-allocation`)}
+          onDragEnd={() => { setDraggingId(null); setOverId(null); }}
           size={chartStates[`portfolio-sample-${i}-asset-allocation`]?.size ?? 'half'}
           minimizable={true}
         >
@@ -603,6 +615,8 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
           onRefresh={onRefresh}
           onMinimize={() => toggleMinimize(`portfolio-sample-${i}-trajectory`)}
           onToggleSize={() => toggleSize(`portfolio-sample-${i}-trajectory`)}
+          onDragStart={() => setDraggingId(`portfolio-sample-${i}-trajectory`)}
+          onDragEnd={() => { setDraggingId(null); setOverId(null); }}
           size={chartStates[`portfolio-sample-${i}-trajectory`]?.size ?? 'half'}
           minimizable={true}
         >
@@ -636,7 +650,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
       );
       return acc;
     }, {} as Record<string, React.ReactNode>),
-  };
+  }), [chartStates, onRefresh, toggleMinimize, toggleSize, stats, sims, currency, sampleRun]);
 
   return (
     <div className="space-y-6">
@@ -866,13 +880,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
                     <span className="px-2 py-1 rounded-md bg-white/90 dark:bg-slate-900/90 text-slate-900 dark:text-slate-100 shadow">Drop Here</span>
                   </div>
                 )}
-                {React.cloneElement<ChartProps>(
-                  charts[chartId],
-                  {
-                    onDragStart: () => setDraggingId(chartId),
-                    onDragEnd: () => { setDraggingId(null); setOverId(null); },
-                  }
-                )}
+                {charts[chartId]}
               </motion.div>
             )
           ))}

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useEffect, useRef } from "react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, Area, AreaChart, CartesianGrid } from "recharts";
 import { LayoutGroup, motion } from "framer-motion";
 import type { DrawdownStrategy } from "../App";
@@ -266,6 +266,17 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
     return map;
   }, [years, bitcoin, sp500, nasdaq100, btcReturns, bondReturns]);
 
+  const firstRender = useRef(true);
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    const id = setTimeout(onRefresh, 1000);
+    return () => clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [startBalance, cash, spy, qqq, bitcoin, bonds, drawdownStrategy, horizon, withdrawRate, initialWithdrawalAmount, inflationAdjust, inflationRate, mode, numRuns, seed, startYear]);
+
   const sims = useMemo(() => {
     const runs: PortfolioRunResult[] = [];
     const initialW = initialWithdrawalAmount / startBalance;
@@ -301,7 +312,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
     }
     return runs;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cash, spy, qqq, bonds, horizon, initialWithdrawalAmount, inflationRate, inflationAdjust, drawdownStrategy, mode, numRuns, startYear, returnsByYear, startBalance, years, refreshCounter]);
+  }, [refreshCounter]);
 
 
   const stats = useMemo(() => {

--- a/src/components/S&P500Tab.tsx
+++ b/src/components/S&P500Tab.tsx
@@ -102,7 +102,7 @@ const SPTab: React.FC<SPTabProps> = ({
       firstRender.current = false;
       return;
     }
-    const id = setTimeout(onRefresh, 1000);
+    const id = setTimeout(onRefresh, 100);
     return () => clearTimeout(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [startBalance, horizon, withdrawRate, inflationRate, inflationAdjust, mode, numRuns, seed, startYear]);
@@ -181,9 +181,9 @@ const SPTab: React.FC<SPTabProps> = ({
   }, [sims, horizon]);
 
   const sampleRun = sims[0];
-  const currency = new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+  const currency = useMemo(() => new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 }), []);
 
-  const charts: Record<string, React.ReactElement<ChartProps>> = {
+  const charts: Record<string, React.ReactElement<ChartProps>> = useMemo(() => ({
     'sp500-trajectory': (
       <Chart
         chartId="sp500-trajectory"
@@ -191,6 +191,8 @@ const SPTab: React.FC<SPTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('sp500-trajectory')}
         onToggleSize={() => toggleSize('sp500-trajectory')}
+        onDragStart={() => setDraggingId('sp500-trajectory')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['sp500-trajectory']?.size ?? 'half'}
         minimizable={true}
       >
@@ -224,6 +226,8 @@ const SPTab: React.FC<SPTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('sp500-median-trajectory')}
         onToggleSize={() => toggleSize('sp500-median-trajectory')}
+        onDragStart={() => setDraggingId('sp500-median-trajectory')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['sp500-median-trajectory']?.size ?? 'half'}
         minimizable={true}
       >
@@ -264,6 +268,8 @@ const SPTab: React.FC<SPTabProps> = ({
         onRefresh={onRefresh}
         onMinimize={() => toggleMinimize('sp500-sample')}
         onToggleSize={() => toggleSize('sp500-sample')}
+        onDragStart={() => setDraggingId('sp500-sample')}
+        onDragEnd={() => { setDraggingId(null); setOverId(null); }}
         size={chartStates['sp500-sample']?.size ?? 'half'}
         minimizable={true}
       >
@@ -307,6 +313,8 @@ const SPTab: React.FC<SPTabProps> = ({
           onRefresh={onRefresh}
           onMinimize={() => toggleMinimize(`sp500-sample-${i}-trajectory`)}
           onToggleSize={() => toggleSize(`sp500-sample-${i}-trajectory`)}
+          onDragStart={() => setDraggingId(`sp500-sample-${i}-trajectory`)}
+          onDragEnd={() => { setDraggingId(null); setOverId(null); }}
           size={chartStates[`sp500-sample-${i}-trajectory`]?.size ?? 'half'}
           minimizable={true}
         >
@@ -340,7 +348,7 @@ const SPTab: React.FC<SPTabProps> = ({
       );
       return acc;
     }, {} as Record<string, React.ReactElement<ChartProps>>),
-  };
+  }), [chartStates, onRefresh, toggleMinimize, toggleSize, stats, sims, currency, sampleRun]);
 
   // Drag & drop state for reordering
   const [draggingId, setDraggingId] = React.useState<string | null>(null);
@@ -556,13 +564,7 @@ const SPTab: React.FC<SPTabProps> = ({
                     <span className="px-2 py-1 rounded-md bg-white/90 dark:bg-slate-900/90 text-slate-900 dark:text-slate-100 shadow">Drop Here</span>
                   </div>
                 )}
-                {React.cloneElement<ChartProps>(
-                  charts[chartId],
-                  {
-                    onDragStart: () => setDraggingId(chartId),
-                    onDragEnd: () => { setDraggingId(null); setOverId(null); },
-                  }
-                )}
+                {charts[chartId]}
               </motion.div>
             )
           ))}

--- a/src/components/S&P500Tab.tsx
+++ b/src/components/S&P500Tab.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useEffect, useRef } from "react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, Area, AreaChart, CartesianGrid } from "recharts";
 import { LayoutGroup, motion } from "framer-motion";
 import { useData } from "../data/DataContext";
@@ -96,6 +96,17 @@ const SPTab: React.FC<SPTabProps> = ({
   const years = useMemo(() => sp500.map(d => d.year).sort((a, b) => a - b), [sp500]);
   const availableMultipliers = useMemo(() => sp500.map(d => pctToMult(d.returnPct)), [sp500]);
 
+  const firstRender = useRef(true);
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    const id = setTimeout(onRefresh, 1000);
+    return () => clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [startBalance, horizon, withdrawRate, inflationRate, inflationAdjust, mode, numRuns, seed, startYear]);
+
   const sims = useMemo(() => {
     const initW = withdrawRate / 100;
     const runs: RunResult[] = [];
@@ -127,7 +138,7 @@ const SPTab: React.FC<SPTabProps> = ({
     }
     return runs;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, numRuns, availableMultipliers, horizon, startBalance, withdrawRate, inflationRate, inflationAdjust, startYear, refreshCounter]);
+  }, [availableMultipliers, sp500, refreshCounter]);
 
   const stats = useMemo(() => {
     if (sims.length === 0) return null;


### PR DESCRIPTION
## Summary
- delay simulation recalculation by 1 second after input changes on all tabs
- rely on debounced refresh counter instead of immediate re-computation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b755adae148324a7b1617a63d6edc5