### PR TITLE
Trigger simulation recompute on data edits

### DIFF
--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -246,7 +246,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
     }
     return runs;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshCounter]);
+  }, [refreshCounter, returnsByYear]);
 
 
   const stats = useMemo(() => {

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -312,7 +312,7 @@ const PortfolioTab: React.FC<PortfolioTabProps> = ({
     }
     return runs;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshCounter]);
+  }, [refreshCounter, returnsByYear]);
 
 
   const stats = useMemo(() => {


### PR DESCRIPTION
## Summary
- Recompute Drawdown and Portfolio simulations when underlying data tables update

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b79afcb6e88324b35f964152ee8481