### PR TITLE
feat: add risk-based guardrails strategy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ export type DrawdownStrategy =
 
 export type DrawdownStrategies =
   | "guytonKlinger"
+  | "riskBasedGuardrails"
   | "floorAndCeiling"
   | "capeBased"
   | "fixedPercentage"

--- a/src/components/DrawdownTab.tsx
+++ b/src/components/DrawdownTab.tsx
@@ -18,6 +18,7 @@ import {
   type PortfolioRunResult,
   type RunResult,
   simulateGuytonKlinger,
+  simulateRiskBasedGuardrails,
   simulateFloorAndCeiling,
   simulateFourPercentRuleRatchetUp,
   simulateFourPercentRule,
@@ -102,6 +103,12 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
     cutPercentage: 0.1,
     raisePercentage: 0.1,
   });
+  const [riskBasedParams, setRiskBasedParams] = React.useState({
+    successUpper: 0.99,
+    successLower: 0.7,
+    cutPercentage: 0.1,
+    raisePercentage: 0.1,
+  });
   const [floorAndCeilingParams, setFloorAndCeilingParams] = React.useState({
     floor: 0.3,
     ceiling: 0.3,
@@ -155,7 +162,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
     const id = setTimeout(onRefresh, 100);
     return () => clearTimeout(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [drawdownWithdrawalStrategy, startBalance, cash, spy, qqq, bitcoin, bonds, horizon, withdrawRate, initialWithdrawalAmount, inflationAdjust, effectiveInflationRate, useHistoricalInflation, mode, numRuns, seed, startYear, guytonKlingerParams, floorAndCeilingParams, capeBasedParams, fixedPercentageParams]);
+  }, [drawdownWithdrawalStrategy, startBalance, cash, spy, qqq, bitcoin, bonds, horizon, withdrawRate, initialWithdrawalAmount, inflationAdjust, effectiveInflationRate, useHistoricalInflation, mode, numRuns, seed, startYear, guytonKlingerParams, riskBasedParams, floorAndCeilingParams, capeBasedParams, fixedPercentageParams]);
 
   const sims = useMemo(() => {
     const runs: PortfolioRunResult[] = [];
@@ -173,6 +180,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
       const inflSeq = useHistoricalInflation ? inflationFromYears(yearSample) : undefined;
       if (strategy === "guytonKlinger") {
         runs.push(simulateGuytonKlinger(spyReturns, qqqReturns, bitcoinReturns, bondReturns, cash, spy, qqq, bitcoin, bonds, horizon, initialW, inflationRate, inflationAdjust, guytonKlingerParams.guardrailUpper, guytonKlingerParams.guardrailLower, guytonKlingerParams.cutPercentage, guytonKlingerParams.raisePercentage, inflSeq));
+      } else if (strategy === "riskBasedGuardrails") {
+        runs.push(simulateRiskBasedGuardrails(spyReturns, qqqReturns, bitcoinReturns, bondReturns, cash, spy, qqq, bitcoin, bonds, horizon, initialW, inflationRate, inflationAdjust, riskBasedParams.successUpper, riskBasedParams.successLower, riskBasedParams.cutPercentage, riskBasedParams.raisePercentage, undefined, inflSeq));
       } else if (strategy === "floorAndCeiling") {
         runs.push(simulateFloorAndCeiling(spyReturns, qqqReturns, bitcoinReturns, bondReturns, cash, spy, qqq, bitcoin, bonds, horizon, initialW, inflationRate, inflationAdjust, floorAndCeilingParams.floor, floorAndCeilingParams.ceiling, inflSeq));
       } else if (strategy === "capeBased") {
@@ -223,6 +232,8 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
         const inflSeq = useHistoricalInflation ? inflationFromYears(yearSample) : undefined;
         if (strategy === "guytonKlinger") {
           runs.push(simulateGuytonKlinger(spyReturns, qqqReturns, bitcoinReturns, bondReturns, cash, spy, qqq, bitcoin, bonds, horizon, initialW, inflationRate, inflationAdjust, guytonKlingerParams.guardrailUpper, guytonKlingerParams.guardrailLower, guytonKlingerParams.cutPercentage, guytonKlingerParams.raisePercentage, inflSeq));
+        } else if (strategy === "riskBasedGuardrails") {
+          runs.push(simulateRiskBasedGuardrails(spyReturns, qqqReturns, bitcoinReturns, bondReturns, cash, spy, qqq, bitcoin, bonds, horizon, initialW, inflationRate, inflationAdjust, riskBasedParams.successUpper, riskBasedParams.successLower, riskBasedParams.cutPercentage, riskBasedParams.raisePercentage, undefined, inflSeq));
         } else if (strategy === "floorAndCeiling") {
           runs.push(simulateFloorAndCeiling(spyReturns, qqqReturns, bitcoinReturns, bondReturns, cash, spy, qqq, bitcoin, bonds, horizon, initialW, inflationRate, inflationAdjust, floorAndCeilingParams.floor, floorAndCeilingParams.ceiling, inflSeq));
         } else if (strategy === "capeBased") {
@@ -768,6 +779,7 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
               <option value="fourPercentRule">4% Rule</option>
               <option value="fourPercentRuleUpwardReset">4% Rule – Upward Reset</option>
               <option value="guytonKlinger">Guyton-Klinger</option>
+              <option value="riskBasedGuardrails">Risk-Based Guardrails</option>
               <option value="floorAndCeiling">Floor and Ceiling</option>
               <option value="capeBased">CAPE-Based</option>
               <option value="fixedPercentage">Fixed % Drawdown</option>
@@ -802,6 +814,26 @@ const DrawdownTab: React.FC<DrawdownTabProps> = ({
                 </label>
                 <label className="block">Cut Percentage (%)
                   <input type="number" className="mt-1 w-full border rounded-xl p-2 bg-white dark:bg-slate-700 dark:border-slate-600" value={guytonKlingerParams.cutPercentage * 100} onChange={e => setGuytonKlingerParams({ ...guytonKlingerParams, cutPercentage: parseFloat(e.target.value) / 100 })} />
+                </label>
+              </div>
+            </div>
+          )}
+
+          {strategy === 'riskBasedGuardrails' && (
+            <div className="text-sm border-t pt-2">
+              <h3 className="font-semibold mb-2">Risk-Based Guardrails adjust withdrawals based on Monte Carlo success probabilities.</h3>
+              <div className="grid grid-cols-2 gap-2">
+                <label className="block">Lower Success Rate (%)
+                  <input type="number" className="mt-1 w-full border rounded-xl p-2 bg-white dark:bg-slate-700 dark:border-slate-600" value={riskBasedParams.successLower * 100} onChange={e => setRiskBasedParams({ ...riskBasedParams, successLower: parseFloat(e.target.value) / 100 })} />
+                </label>
+                <label className="block">Upper Success Rate (%)
+                  <input type="number" className="mt-1 w-full border rounded-xl p-2 bg-white dark:bg-slate-700 dark:border-slate-600" value={riskBasedParams.successUpper * 100} onChange={e => setRiskBasedParams({ ...riskBasedParams, successUpper: parseFloat(e.target.value) / 100 })} />
+                </label>
+                <label className="block">Raise Percentage (%)
+                  <input type="number" className="mt-1 w-full border rounded-xl p-2 bg-white dark:bg-slate-700 dark:border-slate-600" value={riskBasedParams.raisePercentage * 100} onChange={e => setRiskBasedParams({ ...riskBasedParams, raisePercentage: parseFloat(e.target.value) / 100 })} />
+                </label>
+                <label className="block">Cut Percentage (%)
+                  <input type="number" className="mt-1 w-full border rounded-xl p-2 bg-white dark:bg-slate-700 dark:border-slate-600" value={riskBasedParams.cutPercentage * 100} onChange={e => setRiskBasedParams({ ...riskBasedParams, cutPercentage: parseFloat(e.target.value) / 100 })} />
                 </label>
               </div>
             </div>

--- a/src/lib/simulation.test.ts
+++ b/src/lib/simulation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { simulateFourPercentRuleRatchetUp, simulateGuytonKlinger, simulateCapeBased } from './simulation';
+import { simulateFourPercentRuleRatchetUp, simulateGuytonKlinger, simulateCapeBased, simulateRiskBasedGuardrails } from './simulation';
 
 describe('simulateFourPercentRuleRatchetUp', () => {
   const initialSpy = 1000000;
@@ -166,5 +166,50 @@ describe('simulateCapeBased', () => {
     // Year 1 withdrawal rate: 0.02 + 0.5 * (1/30) = 0.036666
     // Withdrawal amount: 967_500 * 0.036666 = 35474.955
     expect(result.withdrawals[1]).toBeCloseTo(35475);
+  });
+});
+
+describe('simulateRiskBasedGuardrails', () => {
+  const initialBalance = 1000000;
+  const horizon = 30;
+  const initialWithdrawalRate = 0.04;
+  const inflationRate = 0.02;
+  const returnsUp = Array(horizon).fill(1.1);
+  const returnsDown = Array(horizon).fill(0.9);
+
+  it('should raise withdrawals when success rate is high', () => {
+    const result = simulateRiskBasedGuardrails(
+      returnsUp, returnsUp, returnsUp, returnsUp,
+      0, initialBalance, 0, 0, 0,
+      horizon,
+      initialWithdrawalRate,
+      inflationRate,
+      false,
+      0.95,
+      0.5,
+      0.1,
+      0.1,
+      1,
+      undefined,
+    );
+    expect(result.withdrawals[1]).toBeCloseTo(44000);
+  });
+
+  it('should cut withdrawals when success rate is low', () => {
+    const result = simulateRiskBasedGuardrails(
+      returnsDown, returnsDown, returnsDown, returnsDown,
+      0, initialBalance, 0, 0, 0,
+      horizon,
+      initialWithdrawalRate,
+      inflationRate,
+      false,
+      0.95,
+      0.5,
+      0.1,
+      0.1,
+      1,
+      undefined,
+    );
+    expect(result.withdrawals[1]).toBeCloseTo(36000);
   });
 });

--- a/src/lib/simulation.ts
+++ b/src/lib/simulation.ts
@@ -215,6 +215,163 @@ export function simulateGuytonKlinger(
   return { balances, withdrawals, failedYear, guardrailTriggers };
 }
 
+export function simulateRiskBasedGuardrails(
+  spyReturns: number[],
+  qqqReturns: number[],
+  bitcoinReturns: number[],
+  bondReturns: number[],
+  initialCash: number,
+  initialSpy: number,
+  initialQqq: number,
+  initialBitcoin: number,
+  initialBonds: number,
+  horizon: number,
+  initialWithdrawalRate: number,
+  inflationRate: number,
+  inflationAdjust: boolean,
+  successUpper: number,
+  successLower: number,
+  cutPercentage: number,
+  raisePercentage: number,
+  mcSamples = 100,
+  inflationRates?: number[],
+): PortfolioRunResult {
+  const balances = new Array(horizon + 1).fill(0).map(() => ({ total: 0, cash: 0, spy: 0, qqq: 0, bitcoin: 0, bonds: 0 }));
+  const withdrawals: number[] = new Array(horizon).fill(0);
+  const guardrailTriggers: number[] = [];
+  let cash = initialCash;
+  let spy = initialSpy;
+  let qqq = initialQqq;
+  let bitcoin = initialBitcoin;
+  let bonds = initialBonds;
+  const startBalance = initialCash + initialSpy + initialQqq + initialBitcoin + initialBonds;
+  let withdrawalAmount = startBalance * initialWithdrawalRate;
+
+  balances[0] = { total: startBalance, cash, spy, qqq, bitcoin, bonds };
+  let failedYear: number | null = null;
+
+  const calcSuccessRate = (
+    c: number,
+    s: number,
+    q: number,
+    btc: number,
+    bd: number,
+    withdraw: number,
+    remaining: number,
+  ) => {
+    let success = 0;
+    for (let i = 0; i < mcSamples; i++) {
+      let cashMC = c, spyMC = s, qqqMC = q, bitcoinMC = btc, bondsMC = bd;
+      let withdrawalMC = withdraw;
+      let failed = false;
+      for (let y = 0; y < remaining; y++) {
+        const fromCash = Math.min(withdrawalMC, cashMC);
+        cashMC -= fromCash;
+        let remW = withdrawalMC - fromCash;
+        if (remW > 0) { const fs = Math.min(remW, spyMC); spyMC -= fs; remW -= fs; }
+        if (remW > 0) { const fq = Math.min(remW, qqqMC); qqqMC -= fq; remW -= fq; }
+        if (remW > 0) { const fb = Math.min(remW, bitcoinMC); bitcoinMC -= fb; remW -= fb; }
+        if (remW > 0) { const fbd = Math.min(remW, bondsMC); bondsMC -= fbd; }
+        const totalBefore = cashMC + spyMC + qqqMC + bitcoinMC + bondsMC;
+        if (totalBefore <= 0) { failed = true; break; }
+        const idx = Math.floor(Math.random() * spyReturns.length);
+        spyMC *= spyReturns[idx];
+        qqqMC *= qqqReturns[idx];
+        bitcoinMC *= bitcoinReturns[idx];
+        bondsMC *= bondReturns[idx];
+        if (inflationAdjust) {
+          const rate = inflationRates ? inflationRates[(horizon - remaining) + y] ?? inflationRate : inflationRate;
+          withdrawalMC *= (1 + rate);
+        }
+      }
+      if (!failed) success++;
+    }
+    return success / mcSamples;
+  };
+
+  for (let y = 0; y < horizon; y++) {
+    withdrawals[y] = withdrawalAmount;
+
+    // Drawdown from cash first
+    const fromCash = Math.min(withdrawalAmount, cash);
+    cash -= fromCash;
+    let remainingWithdrawal = withdrawalAmount - fromCash;
+
+    if (remainingWithdrawal > 0) {
+      const fromSpy = Math.min(remainingWithdrawal, spy);
+      spy -= fromSpy;
+      remainingWithdrawal -= fromSpy;
+
+      if (remainingWithdrawal > 0) {
+        const fromQqq = Math.min(remainingWithdrawal, qqq);
+        qqq -= fromQqq;
+        remainingWithdrawal -= fromQqq;
+      }
+
+      if (remainingWithdrawal > 0) {
+        const fromBitcoin = Math.min(remainingWithdrawal, bitcoin);
+        bitcoin -= fromBitcoin;
+        remainingWithdrawal -= fromBitcoin;
+      }
+
+      if (remainingWithdrawal > 0) {
+        const fromBonds = Math.min(remainingWithdrawal, bonds);
+        bonds -= fromBonds;
+      }
+    }
+
+    const totalBeforeGrowth = cash + spy + qqq + bitcoin + bonds;
+    if (totalBeforeGrowth <= 0 && failedYear === null) {
+      failedYear = y + 1;
+      for (let i = y + 1; i <= horizon; i++) {
+        balances[i] = { total: 0, cash: 0, spy: 0, qqq: 0, bitcoin: 0, bonds: 0 };
+      }
+      break;
+    }
+
+    // Apply market returns
+    const portfolioBeforeGrowth = totalBeforeGrowth;
+    spy *= spyReturns[y];
+    qqq *= qqqReturns[y];
+    bitcoin *= bitcoinReturns[y];
+    bonds *= bondReturns[y];
+    const portfolioAfterGrowth = cash + spy + qqq + bitcoin + bonds;
+    const lastYearReturn = (portfolioAfterGrowth / portfolioBeforeGrowth) - 1;
+
+    const totalAfterGrowth = cash + spy + qqq + bitcoin + bonds;
+    balances[y + 1] = { total: totalAfterGrowth, cash, spy, qqq, bitcoin, bonds };
+
+    // Determine next year's withdrawal amount
+    let nextWithdrawalAmount = withdrawalAmount;
+
+    // Inflation adjustment
+    const currentWithdrawalRate = withdrawalAmount / totalAfterGrowth;
+    if (inflationAdjust) {
+      const rate = inflationRates ? inflationRates[y] : inflationRate;
+      if (lastYearReturn >= 0 || currentWithdrawalRate <= initialWithdrawalRate) {
+        nextWithdrawalAmount *= (1 + rate);
+      }
+    }
+
+    // Risk-based guardrail adjustments
+    if (y < horizon - 15) {
+      const remainingYears = horizon - (y + 1);
+      const successRate = calcSuccessRate(cash, spy, qqq, bitcoin, bonds, nextWithdrawalAmount, remainingYears);
+      if (successRate < successLower) {
+        nextWithdrawalAmount *= (1 - cutPercentage);
+        guardrailTriggers.push(y + 1);
+      } else if (successRate > successUpper) {
+        nextWithdrawalAmount *= (1 + raisePercentage);
+        guardrailTriggers.push(y + 1);
+      }
+    }
+
+    withdrawalAmount = nextWithdrawalAmount;
+  }
+
+  return { balances, withdrawals, failedYear, guardrailTriggers };
+}
+
 export function simulateFloorAndCeiling(
   spyReturns: number[],
   qqqReturns: number[],


### PR DESCRIPTION
## Summary
- add risk-based guardrails drawdown simulation based on success probabilities
- expose risk-based guardrails option in drawdown UI
- cover risk-based guardrails with unit tests

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68c04fb02aac83248f3f949dfca6b42a)